### PR TITLE
Revert "Update dependency puppeteer to v1.12.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "access-log": "0.4.1",
     "neodoc": "2.0.2",
     "node-fetch": "2.3.0",
-    "puppeteer": "1.12.2"
+    "puppeteer": "1.12.1"
   },
   "scripts": {
     "lint": "prettier-eslint --write index.js src/* test/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,9 +1249,9 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
-puppeteer@1.12.2:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.12.2.tgz#dbc36afc3ba2d7182b1a37523c0081a0e8507c9a"
+puppeteer@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.12.1.tgz#440241743f4c909015d0924bdb7f99f670d9c955"
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"


### PR DESCRIPTION
Reverts kitsuyui/rendering-proxy#76

This makes build failure. (puppeteer will be freeze)