### PR TITLE
Pass browser errors via HTTP header

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -17,6 +17,11 @@ const main = async port => {
     const url = req.url.slice(1);
     accesslog(req, res);
     const result = await getRenderedContent(browser, url, evaluate, waitUntil);
+    if (result.errors) {
+      res.statusCode = 502;
+      const errorMessage = encodeURI(result.errors.join("\n"));
+      res.setHeader("X-UA-Errors", errorMessage);
+    }
     for (const key of Object.keys(result.headers)) {
       if (ignoreHeaders.includes(key.toLowerCase())) {
         continue;


### PR DESCRIPTION
Currently browser error such as JavaScript error, image loading error and etc were omitted by the response.
This PR provides access to User-Agent errors.
Edge client can receive the errors via HTTP Response Header `X-UA-Errors`.
Header value is encoded by URL Encoding.
And in case the errors exist, status code will be 502.