### PR TITLE
Solve problems causing by breaking changes from puppeteers between 1.11.0 and 1.15.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,12 @@ jobs:
       - run:
           name: build image
           command: |
+            set -eu
             docker-compose build
       - run:
           name: run tests
           command: |
+            set -eu
             docker-compose run -T --rm rendering-proxy cli testserver/json > /dev/null
             docker-compose run -T --rm rendering-proxy cli testserver/html > /dev/null
             docker-compose run -T --rm rendering-proxy cli testserver/robots.txt > /dev/null

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "access-log": "0.4.1",
     "neodoc": "2.0.2",
     "node-fetch": "2.5.0",
-    "puppeteer": "1.11.0"
+    "puppeteer": "1.15.0"
   },
   "scripts": {
     "lint": "prettier-eslint --write index.js src/* test/*",

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,6 @@ const chromiumOptions = [
   "--safebrowsing-disable-auto-update"
 ];
 
-const htmlContentTypes = ["text/html", "application/xhtml+xml"];
 const uaLogLevels = ["error", "warning"];
 
 const getRenderedContent = async (
@@ -49,14 +48,23 @@ const getRenderedContent = async (
     }
     return await getContent(page, response, errors);
   } finally {
-    await page.close();
+    setImmediate(async () => {
+      await page.close();
+    });
   }
 };
 
+const isContentTypeHTML = (contentType) => {
+  const htmlContentTypes = ["text/html", "application/xhtml+xml"];
+  return htmlContentTypes.some((htmlContentType) => {
+    return contentType.startsWith(htmlContentType);
+  });
+}
+
+
 const getContent = async (page, response, errors) => {
   const headers = Object.assign({}, response.headers());
-  const contentType = headers["content-type"];
-  if (htmlContentTypes.includes(contentType)) {
+  if (isContentTypeHTML(headers["content-type"])) {
     const script = () => document.documentElement.outerHTML;
     const textHTML = await page.evaluate(script);
     return new Response(headers, Buffer.from(textHTML), errors);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,9 +1256,9 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
-puppeteer@1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.11.0.tgz#63cdbe12b07275cd6e0b94bce41f3fcb20305770"
+puppeteer@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.15.0.tgz#1680fac13e51f609143149a5b7fa99eec392b34f"
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"


### PR DESCRIPTION
- This PR includes #90.
- puppeteer's content-type now returns `text/html; charset=UTF-8` instead of `text/html`.
- browser close hangs.
- Fix CI tests that ignoring failures.