### PR TITLE
Disable docker layer caching.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
     steps:
       - checkout


### PR DESCRIPTION
Docker layer caching was changed to require additional fee.
So it cannot to be used.