### PR TITLE
Set up test server

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       interval: 1s
       timeout: 1s
       retries: 10
+    links:
+      - httpbin
+    environment:
+      - RUNNING_IN_DOCKER=true
 
   rendering-proxy-firefox:
     build:
@@ -25,3 +29,10 @@ services:
       interval: 1s
       timeout: 1s
       retries: 10
+    links:
+      - httpbin
+    environment:
+      - RUNNING_IN_DOCKER=true
+
+  httpbin:
+    image: kennethreitz/httpbin


### PR DESCRIPTION
Currently, external sites such as example.com and httpbin.org are used for testing.
Accessing external sites puts a load on the network and is more susceptible to instability, so set up a local test server and access it.

Set up a test server when running jest.
