### PR TITLE
Update supported Node.js versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
           cache-dependency-path: yarn.lock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
         run: npm pack
 
       - name: Upload coverage to Codecov
-        if: matrix.node-version == '18.x'
+        if: matrix.node-version == '20.x'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
14.x is already EOL. Support LTS versions with Security Support enabled: 16.x, 18.x, 20.x
https://endoflife.date/nodejs
