### PR TITLE
Install libsoup for newer version of puppeteer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,12 @@
 FROM mcr.microsoft.com/playwright:v1.37.1-focal
-RUN apt update && apt install libgudev-1.0-0 && apt clean && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y libgudev-1.0-0 libsoup2.4-1 libsoup2.4-dev && apt clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 RUN mkdir -p /app
 ADD pnpm-lock.yaml /app/
 ADD package.json /app/
 
 FROM node:20-slim AS base
+RUN apt update && apt install -y libgudev-1.0-0 libsoup2.4-1 libsoup2.4-dev && apt clean && rm -rf /var/lib/apt/lists/*
 RUN corepack enable && corepack prepare pnpm@latest --activate
 ADD . /app
 WORKDIR /app


### PR DESCRIPTION
To avoid the following error:
```
    browserType.launch:
    ╔══════════════════════════════════════════════════════╗
    ║ Host system is missing dependencies to run browsers. ║
    ║ Missing libraries:                                   ║
    ║     libsoup-2.4.so.1                                 ║
    ╚══════════════════════════════════════════════════════╝
```
