### PR TITLE
Fix integrity hash of external scripts used in test assets

### DIFF
--- a/tests/fixtures/react/index.html
+++ b/tests/fixtures/react/index.html
@@ -4,9 +4,9 @@
 <head>
   <meta charset="UTF-8">
   <title>React Example</title>
-  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" integrity="sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.24.7/babel.min.js" integrity="sha384-AISI5AuDG6E8DeEiFMVB3rGQxhZt24OU0avMp+GMV64+tpnA3+Z6F5MT0f96iPva" crossorigin="anonymous"></script>
   <script type="text/babel">
 
     function factorial(n) {

--- a/tests/fixtures/vue/index.html
+++ b/tests/fixtures/vue/index.html
@@ -3,12 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <title>Vue Example</title>
-    <script crossorigin src="https://unpkg.com/vue@3"></script>
+    <script src="https://unpkg.com/vue@3.4.31/dist/vue.global.js" integrity="sha384-99giBcOL3CzbiilqxjvNuhy9alfjCUjjHWKmf4ErVnTHuMp0UD0HgRuXSxAfZnqc" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/@babel/standalone@7.24.7/babel.min.js" integrity="sha384-AISI5AuDG6E8DeEiFMVB3rGQxhZt24OU0avMp+GMV64+tpnA3+Z6F5MT0f96iPva" crossorigin="anonymous"></script>
 
-    <script
-      crossorigin
-      src="https://unpkg.com/@babel/standalone/babel.min.js"
-    ></script>
     <script type="text/babel">
       const { createApp } = Vue;
 


### PR DESCRIPTION
A supply chain attack was carried out on a site that uses external scripts embedded directly, such as polyfill io.
To avoid concerns for the future, fix the integrity hash of external scripts obtained from unpkg.com.
