### PR TITLE
Perform type checking using tsc --noEmit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: typecheck
+        run: pnpm typecheck
+
       - name: Test
         run: pnpm test
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "tsc",
     "test": "jest",
     "lint": "biome check .",
-    "format": "biome check --write ."
+    "format": "biome check --write .",
+    "typecheck": "tsc --noEmit"
   },
   "bin": {
     "rendering-proxy": "./dist/main.js"


### PR DESCRIPTION
- I had a misunderstanding. I thought that if I used biome.js, it would automatically perform type checking.
- Type checking needs to be performed separately.
- For that purpose, I will use tsc --noEmit.
