### PR TITLE
Use localhost for testing HTML server

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - '@swc/core'

--- a/src/render/index.spec.ts
+++ b/src/render/index.spec.ts
@@ -176,22 +176,28 @@ describe('getRenderedContent', () => {
 })
 
 describe('getRenderedContent with evaluates', () => {
+  jest.setTimeout(30000)
   let browser: Browser
+  let htmlServer: ChildProcess
 
   beforeAll(async () => {
     browser = await getBrowser()
+    htmlServer = spawn('http-server', ['-p', '8004', 'tests/fixtures/html'])
+    await sleep(3000)
   })
   afterAll(async () => {
     await browser.close()
+    htmlServer.kill()
   })
 
   it('works', async () => {
     const result = await getRenderedContent(browser, {
-      url: 'http://example.com/',
+      url: 'http://localhost:8004/test.html',
       evaluates: ['document.title', 'navigator.userAgent', '1 + 1'],
     })
+    console.log(result)
     expect(result.evaluateResults[0].script).toBe('document.title')
-    expect(result.evaluateResults[0].result).toBe('Example Domain')
+    expect(result.evaluateResults[0].result).toBe('Example Title')
     expect(result.evaluateResults[1].script).toBe('navigator.userAgent')
     expect(result.evaluateResults[1].result).toContain('Mozilla/5.0')
     expect(result.evaluateResults[2].script).toBe('1 + 1')
@@ -200,7 +206,7 @@ describe('getRenderedContent with evaluates', () => {
 
   it('works with errors', async () => {
     const result = await getRenderedContent(browser, {
-      url: 'http://example.com/',
+      url: 'http://localhost:8004/test.html',
       evaluates: [
         'document.title',
         'throw new Error("error")',
@@ -208,7 +214,7 @@ describe('getRenderedContent with evaluates', () => {
       ],
     })
     expect(result.evaluateResults[0].script).toBe('document.title')
-    expect(result.evaluateResults[0].result).toBe('Example Domain')
+    expect(result.evaluateResults[0].result).toBe('Example Title')
     expect(result.evaluateResults[1].script).toBe('throw new Error("error")')
     expect(result.evaluateResults[1].result).toContain('Error')
     expect(result.evaluateResults[1].success).toBe(false)
@@ -218,7 +224,7 @@ describe('getRenderedContent with evaluates', () => {
 
   it('can update content body', async () => {
     const result = await getRenderedContent(browser, {
-      url: 'http://example.com/',
+      url: 'http://localhost:8004/test.html',
       evaluates: ['document.title = "Updated Title"'],
     })
     expect(result.evaluateResults[0].script).toBe(

--- a/tests/fixtures/html/test.html
+++ b/tests/fixtures/html/test.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example Title</title>
+  </head>
+  <body>
+    Hello, World!
+  </body>
+</html>


### PR DESCRIPTION
- Changed the test code to use localhost instead of example.com.
  This makes the tests more stable and less dependent on external environments.
