### PR TITLE
Add gh-build-size reporting for dist artifacts

### DIFF
--- a/.github/gh-build-size.yml
+++ b/.github/gh-build-size.yml
@@ -1,0 +1,33 @@
+version: 1
+publish:
+  enabled: true
+  branch: gh-build-size-assets
+comment:
+  key: dist-build-size
+targets:
+  - id: total
+    label: Total dist artifacts
+    files:
+      - dist/**
+    compressions: [raw, gzip, brotli]
+    badge:
+      compression: gzip
+      label: dist artifacts (gzip)
+  - id: runtime
+    label: Runtime bundles
+    files:
+      - dist/**/*.js
+      - dist/**/*.mjs
+    compressions: [raw, gzip, brotli]
+  - id: sourcemaps
+    label: Source maps
+    files:
+      - dist/**/*.map
+    compressions: [raw, gzip, brotli]
+  - id: types
+    label: Type declarations
+    files:
+      - dist/**/*.d.ts
+      - dist/**/*.d.mts
+      - dist/**/*.d.cts
+    compressions: [raw, gzip, brotli]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -28,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install Bun prerequisites
         run: |
@@ -53,6 +58,12 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Measure build size
+        if: matrix.node-version == '24.x'
+        uses: kitsuyui/gh-build-size@v0.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test packaging
         run: bun pm pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,10 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Mark workspace as a safe Git directory
+        if: matrix.node-version == '24.x'
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Measure build size
         if: matrix.node-version == '24.x'
         uses: kitsuyui/gh-build-size@v0.1.2

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 Fetching rendered DOM easily and simply. Like cURL.
 Using [Headless Chromium](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md).
 The repository tracks `TODO` and `@ts-expect-error` markers with [`gh-counter`](https://github.com/kitsuyui/gh-counter).
+It also tracks built `dist/` artifact size with [`gh-build-size`](https://github.com/kitsuyui/gh-build-size).
 
 ![rendering-proxy](https://user-images.githubusercontent.com/2596972/43354885-7dad9750-928e-11e8-9220-821348efca5e.png)
 


### PR DESCRIPTION
## Summary

- add `gh-build-size` configuration for `dist/` build outputs
- run `gh-build-size@v0.1.2` after the representative build job in CI
- mention build size tracking in the README

## Verification

- `git diff --check`
