### PR TITLE
Add gh-build-size badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://badge.fury.io/js/rendering-proxy.svg)](https://badge.fury.io/js/rendering-proxy)
 ![Coverage](https://raw.githubusercontent.com/kitsuyui/octocov-central/main/badges/kitsuyui/rendering-proxy/coverage.svg)
 [![TODO/expect-error](https://raw.githubusercontent.com/kitsuyui/rendering-proxy/gh-counter-assets/badges/maintenance-comments.svg)](https://github.com/kitsuyui/rendering-proxy/search?q=%28TODO+OR+%22%40ts-expect-error%22%29+path%3Asrc&type=code)
+[![Build Size Report](https://raw.githubusercontent.com/kitsuyui/rendering-proxy/gh-build-size-assets/badges/total.svg)](https://github.com/kitsuyui/rendering-proxy/blob/gh-build-size-assets/report.md)
 [![test](https://github.com/kitsuyui/rendering-proxy/actions/workflows/test.yml/badge.svg)](https://github.com/kitsuyui/rendering-proxy/actions/workflows/test.yml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/kitsuyui/rendering-proxy.svg)](https://hub.docker.com/r/kitsuyui/rendering-proxy/)
 


### PR DESCRIPTION
## Summary

- add the published `gh-build-size` badge to the README header
- link the badge to the generated `report.md` on the publish branch

## Verification

- `git diff --check`
