### PR TITLE
Avoid exiting before CLI output flushes

### DIFF
--- a/src/cli/index.spec.ts
+++ b/src/cli/index.spec.ts
@@ -54,18 +54,23 @@ describe('main', () => {
 
   const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((
     str: string | Uint8Array,
+    _encoding?: BufferEncoding,
+    callback?: (error?: Error | null) => void,
   ) => {
     outputs.push(str.toString())
+    callback?.()
+    return true
   }) as (
     str: string | Uint8Array,
     encoding?: BufferEncoding | undefined,
-  ) => never)
+    callback?: (error?: Error | null) => void,
+  ) => boolean)
 
   it('main', async () => {
     expect(called).toBe(false)
     expect(outputs).toStrictEqual([])
     await main({ url: `${httpbinUrl}/robots.txt`, name: 'chromium' })
-    expect(called).toBe(true)
+    expect(called).toBe(false)
     expect(outputs).toMatchSnapshot()
     spy.mockClear()
   })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,7 +12,21 @@ interface CLiRequest extends RenderRequest {
 
 export async function main(request: CLiRequest): Promise<void> {
   await renderToStream(request, process.stdout)
-  process.exit()
+}
+
+async function writeToStream(
+  writable: Writable,
+  body: string | Buffer,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    writable.write(body, 'binary', (error: Error | null | undefined) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
 }
 
 export async function renderToStream(
@@ -29,6 +43,6 @@ export async function renderToStream(
       waitUntil: request.waitUntil,
       evaluates: request.evaluates,
     })
-    writable.write(result.body, 'binary')
+    await writeToStream(writable, result.body)
   })
 }


### PR DESCRIPTION
## Summary

Avoid forcing the CLI process to exit immediately after writing rendered output.

## Details

- Remove the explicit `process.exit()` from CLI `main()`.
- Await the `Writable.write` callback so output back-pressure has a chance to flush before `main()` resolves.
- Update the CLI regression test to assert that `main()` writes the rendered body without forcing process exit.

## Verification

- `bun install`
- `bun run test src/cli/index.spec.ts`
- `bun run typecheck`
- `git diff --check`

Note: `bun run lint` currently fails before checking source files because the existing `biome.json` contains keys rejected by the installed Biome schema (`assist`, `useNumberNamespace`, `trailingCommas`, and `files.includes`).
