### PR TITLE
fix: correct Firefox healthcheck URL

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - "8081:8080"
     healthcheck:
-      test: ["CMD", "curl", "http://127.0.0.1:8080/heatlh/"]
+      test: ["CMD", "curl", "http://127.0.0.1:8080/health/"]
       interval: 1s
       timeout: 3s
       retries: 10


### PR DESCRIPTION
## Summary
- Correct the Firefox service healthcheck URL from `/heatlh/` to `/health/`.
- Keep the Firefox healthcheck aligned with the server route and Chromium service.

## Validation
- Ran `docker compose -f docker/docker-compose.yml config`.

## Issue
- Related finding: https://github.com/kitsuyui/kimono/issues/104
