### PR TITLE
test: wait for each fixture server

### DIFF
--- a/src/render/index.spec.ts
+++ b/src/render/index.spec.ts
@@ -64,8 +64,8 @@ describe('getRenderedContent', () => {
     vueServer = spawn('http-server', ['-p', '8002', 'tests/fixtures/vue'])
     imageServer = spawn('http-server', ['-p', '8003', 'tests/fixtures/images'])
     await waitServerReady('http://localhost:8001/')
-    await waitServerReady('http://localhost:8001/')
-    await waitServerReady('http://localhost:8001/')
+    await waitServerReady('http://localhost:8002/')
+    await waitServerReady('http://localhost:8003/')
   })
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary
- Wait for the React, Vue, and image fixture servers on their own ports.
- Avoid treating repeated checks against port 8001 as coverage for ports 8002 and 8003.

## Validation
- Ran `npm exec --yes --package @biomejs/biome@2.2.5 -- biome check src/render/index.spec.ts`.
- Ran `bun install --frozen-lockfile`.
- Ran `bun run lint`.

## Issue
- Related finding: https://github.com/kitsuyui/kimono/issues/104
