### PR TITLE
Pin write-capable shared workflow refs

### DIFF
--- a/.github/workflows/gh-counter.yml
+++ b/.github/workflows/gh-counter.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   gh-counter:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gh-counter.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gh-counter.yml@a7071a4635eaece62696cd7132306616ce283c47

--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: write
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@a7071a4635eaece62696cd7132306616ce283c47

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -7,4 +7,4 @@ permissions:
   issues: write
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@a7071a4635eaece62696cd7132306616ce283c47


### PR DESCRIPTION
## Summary

- Pin write-capable reusable workflow references to a specific commit SHA.
- Keep the existing triggers and workflow permissions unchanged.

## Validation

- git diff --check
- ruby -e 'require "yaml"; %w[.github/workflows/gh-counter.yml .github/workflows/gitignore-in.yml .github/workflows/happy.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'\n- actionlint .github/workflows/gh-counter.yml .github/workflows/gitignore-in.yml .github/workflows/happy.yml