### PR TITLE
Pin release workflow actions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -7,27 +7,30 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+permissions:
+  contents: read
+
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: kitsuyui/rendering-proxy
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         if: github.event_name == 'release' && !github.event.release.prerelease
         with:
           context: .

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,11 +1,15 @@
 name: test with docker
 on:
   - pull_request
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build docker image
         run: |

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -28,14 +28,14 @@ jobs:
         node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Bun prerequisites
         run: |
           apt-get update
           apt-get install -y unzip
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
@@ -60,7 +60,7 @@ jobs:
 
       # See also: https://github.com/k1LoW/octocov-action
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,20 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
@@ -48,12 +51,12 @@ jobs:
             exit 1
           fi
           tempdir=$(mktemp -d)
-          cd $tempdir
+          cd "$tempdir"
           printf '{"name":"tmp","private":true}\n' > package.json
           bun add "file:$tarball"
           bunx --bun rendering-proxy --help
-          cd $built_dir
-          rm -rf $tempdir
+          cd "$built_dir"
+          rm -rf "$tempdir"
 
       - run: npm publish
         if: github.event_name == 'release' && !github.event.release.prerelease

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
           apt-get update
           apt-get install -y unzip
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
@@ -65,7 +65,7 @@ jobs:
 
       - name: Measure build size
         if: matrix.node-version == '24.x'
-        uses: kitsuyui/gh-build-size@v0.1.2
+        uses: kitsuyui/gh-build-size@97ad8d5f4fff8ba676a5c614822adacab32780e3 # v0.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Pin release, Docker, coverage, and build-size workflow actions to immutable commit SHAs.
- Add explicit `contents: read` permissions to release and Docker workflows that did not declare permissions.
- Quote temporary directory paths in the release packaging smoke test so `actionlint`/ShellCheck passes.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; %w[.github/workflows/release.yml .github/workflows/docker-release.yml .github/workflows/test.yml .github/workflows/docker-test.yml .github/workflows/octocov.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'`\n- `actionlint .github/workflows/release.yml .github/workflows/docker-release.yml .github/workflows/test.yml .github/workflows/docker-test.yml .github/workflows/octocov.yml`\n- `bun install --frozen-lockfile`\n- `bun run lint`\n- `bun run typecheck`\n- `bun run build`\n\n`bun run test` was attempted locally, but this machine does not have the Playwright Chromium binary installed. The pull request checks run tests in the repository Playwright container.\n\nNo release or publish command was run.