### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+Thank you for taking the time to improve rendering-proxy.
+
+## Development setup
+
+This project uses [Bun](https://bun.sh/) for dependency management and scripts.
+
+```sh
+bun install
+```
+
+## Checks
+
+Run formatting before opening a pull request:
+
+```sh
+bun run format
+```
+
+Run lint checks:
+
+```sh
+bun run lint
+```
+
+Run type checks:
+
+```sh
+bun run typecheck
+```
+
+Run the test suite:
+
+```sh
+bun run test
+```
+
+Build the package when changing package metadata, exports, or runtime entrypoints:
+
+```sh
+bun run build
+```
+
+## Pull requests
+
+Before opening a pull request, please make sure that:
+
+- the change is focused on one topic;
+- relevant checks pass locally;
+- README or package documentation updates are included when behavior changes.
+
+When reporting a failing check, include the command you ran and the relevant
+error output.


### PR DESCRIPTION
## Summary
- Add a CONTRIBUTING guide with setup, formatting, lint, type-check, test, and build commands.
- Document basic expectations for focused pull requests and local verification.

## Verification
- `bun run format`
- `git diff --check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

Related to kitsuyui/kimono#104.