### PR TITLE
Pin spellcheck workflow ref

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@b48db82eb82c1f469430bb981812e58aca61d5b5


### PR DESCRIPTION
## Summary
- Pin the reusable spellcheck workflow to an immutable commit SHA.
- Keep the workflow behavior unchanged while avoiding a moving branch ref.

## Verification
- `actionlint .github/workflows/*.yml`
- `git diff --check origin/main...HEAD`
- Confirmed the pinned reusable workflow ref resolves through the GitHub API.
