### PR TITLE
fix: strip cache validation headers for rendered HTML responses

### DIFF
--- a/src/lib/headers.spec.ts
+++ b/src/lib/headers.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   appendVaryHeader,
+  excludeCacheValidationHeaders,
   excludeContentDependentHeaders,
   excludeHopByHopHeaders,
   excludeOriginSecurityContextHeaders,
@@ -108,6 +109,35 @@ describe('excludeOriginSecurityContextHeaders', () => {
       }),
     ).toStrictEqual({
       etag: '"abc"',
+      'content-type': 'text/html',
+      'x-custom': 'value',
+    })
+  })
+})
+
+describe('excludeCacheValidationHeaders', () => {
+  it('removes etag, last-modified, vary, and cache-control', () => {
+    expect(excludeCacheValidationHeaders({})).toStrictEqual({})
+    expect(
+      excludeCacheValidationHeaders({
+        etag: '"abc123"',
+        'last-modified': 'Wed, 01 Jan 2025 00:00:00 GMT',
+        vary: 'Accept-Encoding',
+        'cache-control': 'max-age=3600',
+        'content-type': 'text/html; charset=utf-8',
+      }),
+    ).toStrictEqual({
+      'content-type': 'text/html; charset=utf-8',
+    })
+  })
+
+  it('preserves non-cache headers', () => {
+    expect(
+      excludeCacheValidationHeaders({
+        'content-type': 'text/html',
+        'x-custom': 'value',
+      }),
+    ).toStrictEqual({
       'content-type': 'text/html',
       'x-custom': 'value',
     })

--- a/src/lib/headers.ts
+++ b/src/lib/headers.ts
@@ -30,6 +30,16 @@ const originSecurityContextHeaders = [
   'clear-site-data',
 ]
 
+// Cache validation headers are tied to the origin body, not the rendered DOM.
+// Forwarding them for rendered HTML would associate stale validation tokens
+// with content that differs from what the origin computed them against.
+const cacheValidationHeaders = [
+  'etag',
+  'last-modified',
+  'vary',
+  'cache-control',
+]
+
 type Headers = {
   [key: string]: string
 }
@@ -133,6 +143,24 @@ export function excludeOriginSecurityContextHeaders(headers: Headers): Headers {
   const result: Headers = {}
   for (const key in headers) {
     if (originSecurityContextHeaders.includes(key)) {
+      continue
+    }
+    result[key] = headers[key]
+  }
+  return result
+}
+
+/**
+ * Exclude cache validation headers from the response headers.
+ * Use this when the response body was transformed (e.g. rendered DOM instead of
+ * origin HTML), so the origin's cache tokens no longer describe the actual body.
+ * @param headers {Headers}
+ * @returns headers {Headers}
+ */
+export function excludeCacheValidationHeaders(headers: Headers): Headers {
+  const result: Headers = {}
+  for (const key in headers) {
+    if (cacheValidationHeaders.includes(key)) {
       continue
     }
     result[key] = headers[key]

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,6 +1,8 @@
 import type { Browser, Page, Response as PlaywrightResponse } from 'playwright'
 import { runWithDefer } from 'with-defer'
 
+import { excludeCacheValidationHeaders } from '../lib/headers'
+
 export const lifeCycleEvents = [
   'load',
   'domcontentloaded',
@@ -98,6 +100,16 @@ async function navigatePage(
   }
 }
 
+function computeResponseHeaders(response: PlaywrightResponse): {
+  [key: string]: string
+} {
+  const headers = { ...response.headers() }
+  if (isRenderableContentType(headers['content-type'] || '')) {
+    return excludeCacheValidationHeaders(headers)
+  }
+  return headers
+}
+
 async function readRenderedBody(
   page: Page,
   response: PlaywrightResponse,
@@ -128,10 +140,9 @@ export async function getRenderedContent(
       return emptyRenderResult()
     }
 
-    const headers = { ...navigationResult.response.headers() }
     return {
       status: navigationResult.response.status(),
-      headers,
+      headers: computeResponseHeaders(navigationResult.response),
       body: await readRenderedBody(page, navigationResult.response),
       evaluateResults: navigationResult.evaluateResults,
     }


### PR DESCRIPTION
## Summary

When the proxy renders an HTML page, the response body is the Playwright-rendered DOM (`page.content()`), not the raw origin HTML. However, origin cache validation headers (`etag`, `last-modified`, `vary`, `cache-control`) were forwarded unchanged. These headers were computed against the origin body, so they no longer accurately describe the rendered response.

Downstream caches, CDNs, and browsers using `If-None-Match` / `If-Modified-Since` revalidation would receive stale or misleading answers as a result.

## Changes

- **`src/lib/headers.ts`**: Add `excludeCacheValidationHeaders()`, which strips `etag`, `last-modified`, `vary`, and `cache-control` from a headers map.
- **`src/render/index.ts`**: Add `computeResponseHeaders()` that applies `excludeCacheValidationHeaders()` only for renderable content types (currently `text/html`). Non-HTML responses pass origin headers through unchanged.
- **`src/lib/headers.spec.ts`**: Add unit tests covering both the removal and the preservation of non-cache headers.

## Verification

- All existing tests pass.
- New tests confirm that `etag`, `last-modified`, `vary`, and `cache-control` are stripped for HTML, and that unrelated headers are preserved.

## Trade-offs

Stripping these headers means HTML responses have no cache-control directive downstream — caches may apply their own default TTL. A future improvement could synthesize a `cache-control: no-store` or a fresh `etag` from the rendered DOM hash, but that is out of scope for this fix.
