### PR TITLE
fix: return 502/504 instead of 204 on navigation failure

### DIFF
--- a/src/render/index.spec.ts
+++ b/src/render/index.spec.ts
@@ -127,6 +127,16 @@ describe('getRenderedContent', () => {
     expect(browser.contexts().length).toBe(0)
   })
 
+  it('returns 502 when navigation fails (connection refused)', async () => {
+    const result = await getRenderedContent(browser, {
+      url: 'http://127.0.0.1:19999/',
+    })
+    expect(result.status).toEqual(502)
+    expect(result.body.byteLength).toBe(0)
+    expect(result.evaluateResults).toHaveLength(0)
+    expect(browser.contexts.length).toBe(0)
+  })
+
   test('image/png', async () => {
     const result = await getRenderedContent(browser, {
       url: 'http://localhost:8003/test.png',

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -30,6 +30,15 @@ export interface RenderResult {
   evaluateResults: EvaluateResult[]
 }
 
+function emptyRenderResult(): RenderResult {
+  return {
+    status: 204,
+    headers: {},
+    body: Buffer.from(''),
+    evaluateResults: [],
+  }
+}
+
 function errorRenderResult(status: 502 | 504): RenderResult {
   return {
     status,

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,4 +1,5 @@
 import type { Browser, Page, Response as PlaywrightResponse } from 'playwright'
+import { errors as PlaywrightErrors } from 'playwright'
 import { runWithDefer } from 'with-defer'
 
 import { excludeCacheValidationHeaders } from '../lib/headers'
@@ -29,9 +30,9 @@ export interface RenderResult {
   evaluateResults: EvaluateResult[]
 }
 
-function emptyRenderResult(): RenderResult {
+function errorRenderResult(status: 502 | 504): RenderResult {
   return {
-    status: 204,
+    status,
     headers: {},
     body: Buffer.from(''),
     evaluateResults: [],
@@ -71,13 +72,40 @@ async function collectEvaluateResults(
   )
 }
 
-async function navigatePage(
+type NavigationResult =
+  | {
+      ok: true
+      response: PlaywrightResponse | null
+      evaluateResults: EvaluateResult[]
+    }
+  | { ok: false; status: 502 | 504 }
+
+function classifyNavigationError(error: unknown): 502 | 504 {
+  return error instanceof PlaywrightErrors.TimeoutError ? 504 : 502
+}
+
+function captureNavigationResponse(page: Page): {
+  get: () => PlaywrightResponse | null
+  detach: () => void
+} {
+  let captured: PlaywrightResponse | null = null
+  const handler = (response: PlaywrightResponse) => {
+    if (response.request().isNavigationRequest()) {
+      captured = response
+    }
+  }
+  page.on('response', handler)
+  return {
+    get: () => captured,
+    detach: () => page.off('response', handler),
+  }
+}
+
+async function tryGoto(
   page: Page,
   request: Required<Pick<RenderRequest, 'url' | 'waitUntil'>> & RenderRequest,
-): Promise<{
-  response: PlaywrightResponse | null
-  evaluateResults: EvaluateResult[]
-} | null> {
+  capture: ReturnType<typeof captureNavigationResponse>,
+): Promise<NavigationResult> {
   try {
     const response = await page.goto(request.url, {
       waitUntil: request.waitUntil,
@@ -87,13 +115,9 @@ async function navigatePage(
       page,
       request.evaluates,
     )
-    return {
-      response,
-      evaluateResults,
-    }
+    return { ok: true, response: response ?? capture.get(), evaluateResults }
   } catch (error) {
-    console.error(`navigate failed: ${request.url}`, error)
-    return null
+    return { ok: false, status: classifyNavigationError(error) }
   }
 }
 
@@ -107,15 +131,58 @@ function computeResponseHeaders(response: PlaywrightResponse): {
   return headers
 }
 
+async function navigatePage(
+  page: Page,
+  request: Required<Pick<RenderRequest, 'url' | 'waitUntil'>> & RenderRequest,
+): Promise<NavigationResult> {
+  // Track the main-frame response so we can detect server replies even when
+  // page.goto() throws (e.g. 204 No Content aborts the document load).
+  const capture = captureNavigationResponse(page)
+  const result = await tryGoto(page, request, capture)
+  capture.detach()
+  const serverResponse = capture.get()
+  if (!result.ok && serverResponse) {
+    return { ok: true, response: serverResponse, evaluateResults: [] }
+  }
+  return result
+}
+
+function hasNoBody(status: number): boolean {
+  return status === 204 || status === 304 || (status >= 100 && status < 200)
+}
+
 async function readRenderedBody(
   page: Page,
   response: PlaywrightResponse,
 ): Promise<Buffer> {
+  if (hasNoBody(response.status())) {
+    return Buffer.from('')
+  }
   const headers = { ...response.headers() }
   if (isRenderableContentType(headers['content-type'] || '')) {
     return Buffer.from(await page.content())
   }
   return response.body()
+}
+
+async function buildRenderResult(
+  page: Page,
+  navigationResult: NavigationResult,
+): Promise<RenderResult> {
+  if (!navigationResult.ok) {
+    return errorRenderResult(navigationResult.status)
+  }
+  if (!navigationResult.response) {
+    // page.goto() returned null without an exception (e.g. origin sent 204 No Content).
+    // This is a valid upstream response, not a gateway error.
+    return emptyRenderResult()
+  }
+  return {
+    status: navigationResult.response.status(),
+    headers: computeResponseHeaders(navigationResult.response),
+    body: await readRenderedBody(page, navigationResult.response),
+    evaluateResults: navigationResult.evaluateResults,
+  }
 }
 
 export async function getRenderedContent(
@@ -133,15 +200,6 @@ export async function getRenderedContent(
     const page = await context.newPage()
 
     const navigationResult = await navigatePage(page, normalizedRequest)
-    if (!navigationResult?.response) {
-      return emptyRenderResult()
-    }
-
-    return {
-      status: navigationResult.response.status(),
-      headers: computeResponseHeaders(navigationResult.response),
-      body: await readRenderedBody(page, navigationResult.response),
-      evaluateResults: navigationResult.evaluateResults,
-    }
+    return buildRenderResult(page, navigationResult)
   })
 }


### PR DESCRIPTION
## Summary

When `page.goto()` throws a network error (DNS failure, connection refused, TLS error, etc.), the proxy was silently returning HTTP 204 No Content. This is misleading: 204 means the server explicitly sent "no content", but a thrown error means the upstream was unreachable.

This PR changes the behaviour:
- `TimeoutError` from Playwright → **504 Gateway Timeout**
- Other network errors (DNS, connection refused, TLS) → **502 Bad Gateway**

## Distinguishing errors from valid 204 responses

`page.goto()` also throws when the server legitimately returns 204 No Content, because Playwright aborts the document load when there is no HTML body to parse. A naive error→502 mapping would break the existing 204 pass-through.

To solve this, a `response` event listener captures the main-frame HTTP response before `page.goto()` throws. If a response was captured, the server did reply — Playwright simply could not load a document from it — so the captured response is forwarded as-is. Only when no response was captured at all (genuine connection failure) does the proxy return 502/504.

## Changes

- **`src/render/index.ts`**:
  - `captureNavigationResponse()` — attaches a `response` event listener and exposes the captured main-frame response.
  - `classifyNavigationError()` — maps a caught error to 502 or 504.
  - `tryGoto()` — wraps `page.goto()` in a try/catch using the helpers above.
  - `navigatePage()` — orchestrates the capture and classifies the outcome.
  - `hasNoBody()` / `readRenderedBody()` — skip `response.body()` for status codes that carry no body by spec (204, 304, 1xx).
  - `errorRenderResult()` — builds an empty error response for 502/504.

- **`src/render/index.spec.ts`**: Add a test that navigates to `http://127.0.0.1:19999/` (nothing listening) and expects HTTP 502.

## Verification

All 36 tests pass, including the pre-existing "can handle empty response" test (204 pass-through) and the new 502 test.

## Trade-offs

The response-event approach is more robust than inspecting error message strings, but it does add a `response` listener per request. The listener is always detached before the function returns, so there is no leak across requests.
