### PR TITLE
fix: guard async request handler against unhandled rejections

### DIFF
--- a/src/server/index.spec.ts
+++ b/src/server/index.spec.ts
@@ -106,6 +106,28 @@ describe('withServer', () => {
     })
   })
 
+  it('returns 502 when browser becomes unavailable', async () => {
+    const port = 8093
+    const browser = await getBrowser()
+    const server = await createServer({ browser, port })
+
+    try {
+      await browser.close()
+
+      const res: IncomingMessage = await new Promise((resolve) => {
+        return http.get(
+          `http://localhost:${port}/${httpbinUrl}/json`,
+          (res) => {
+            return resolve(res)
+          },
+        )
+      })
+      expect(res.statusCode).toBe(502)
+    } finally {
+      server.close()
+    }
+  })
+
   it('responses health', async () => {
     const port = 8092
     const res = await runWithDefer(async (defer) => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -91,12 +91,21 @@ async function respondToIncomingRequest(
   await handlers[parsedRequest.type]()
 }
 
+function replyWithBadGateway(res: http.ServerResponse): void {
+  if (!res.headersSent) {
+    res.writeHead(502)
+    res.end()
+  }
+}
+
 export function createHandler(browser: Browser) {
-  return async function renderHandler(
+  return function renderHandler(
     req: http.IncomingMessage,
     res: http.ServerResponse,
   ) {
-    await respondToIncomingRequest(browser, req, res)
+    respondToIncomingRequest(browser, req, res).catch(() =>
+      replyWithBadGateway(res),
+    )
   }
 }
 


### PR DESCRIPTION
## Summary

`Node.js http.createServer()` ignores the `Promise` returned by an async request handler. When `respondToIncomingRequest()` rejects — for example because the browser has crashed and `browser.newPage()` throws — `res.end()` is never called. The client then hangs until its own timeout expires, and the unhandled rejection propagates to `process.unhandledRejection` where it cannot access the per-request `res` object.

## Changes

**`src/server/index.ts`**:
- Extract `replyWithBadGateway(res)`, which writes HTTP 502 to the response if headers have not been sent yet.
- Change `createHandler` so that the returned handler is a synchronous function that calls `respondToIncomingRequest(...).catch(() => replyWithBadGateway(res))`. This ensures every rejection sends a response immediately instead of leaving the client hanging.

**`src/server/index.spec.ts`**:
- Add a test that closes the browser before a request arrives and verifies the response is HTTP 502.

## Verification

All 36 tests pass, including the new browser-unavailable test.

## Trade-offs

The `.catch()` approach replaces a floating `async function` with a plain function that returns `void`. Lint complexity is reduced as a side effect. The 502 response does not distinguish between browser crashes and other handler errors; a future improvement could add structured logging or specific error codes, but that is out of scope here.
