### PR TITLE
fix: narrow EvaluateResult to discriminated union and fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ yarn run rendering-proxy cli https://example.com/ -e 'document.title = "update
 ### Server mode
 
 Send the options via request header `X-Rendering-Proxy` (case-insensitive).
-Receive the results via request header `X-Rendering-Proxy` (case-insensitive).
+Receive the results via response header `X-Rendering-Proxy` (case-insensitive).
 
 ```console
 curl -H 'X-Rendering-Proxy: {"evaluates": ["1 + 1"], "waitUntil": "load"}' --include http://localhost:8080/https://example.com/

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -15,11 +15,9 @@ export interface RenderRequest {
   evaluates?: string[]
 }
 
-export interface EvaluateResult {
-  success: boolean
-  script: string
-  result: unknown
-}
+export type EvaluateResult =
+  | { success: true; script: string; result: unknown }
+  | { success: false; script: string; result: string }
 
 export interface RenderResult {
   status: number


### PR DESCRIPTION
## Summary

- Refactor `EvaluateResult` from a flat interface to a discriminated union type, so TypeScript can narrow `result` to `string` when `success === false` without an explicit cast.
- Fix a typo in README.md Server mode section: "request header" → "response header".

## Changes

### `src/render/index.ts`

`EvaluateResult` was previously defined as a flat interface with `result: unknown`. This meant callers handling the error case had to cast `result` to `string` manually, losing type safety.

The new discriminated union makes the type relationship explicit:

```ts
// Before
export interface EvaluateResult {
  success: boolean
  script: string
  result: unknown
}

// After
export type EvaluateResult =
  | { success: true; script: string; result: unknown }
  | { success: false; script: string; result: string }
```

After checking `success === false`, TypeScript automatically narrows `result` to `string` — no cast required.

### `README.md`

The Server mode section incorrectly described the evaluate results as arriving via a **request** header. Fixed to **response** header, which is where the proxy actually delivers the results.

## Verification

- All 35 tests pass (`bun run test`)
- Typecheck passes (`bun run typecheck`)
- Lint passes (`bun run lint`)
