### PR TITLE
fix: vary rendered responses by proxy options

### DIFF
--- a/src/lib/headers.spec.ts
+++ b/src/lib/headers.spec.ts
@@ -1,10 +1,51 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  appendVaryHeader,
   excludeContentDependentHeaders,
   excludeHopByHopHeaders,
   excludeUnusedHeaders,
 } from './headers'
+
+describe('appendVaryHeader', () => {
+  it('adds Vary when no Vary header exists', () => {
+    expect(appendVaryHeader({}, 'x-rendering-proxy')).toStrictEqual({
+      vary: 'x-rendering-proxy',
+    })
+  })
+
+  it('appends to an existing Vary header', () => {
+    expect(
+      appendVaryHeader(
+        {
+          vary: 'accept-encoding',
+        },
+        'x-rendering-proxy',
+      ),
+    ).toStrictEqual({
+      vary: 'accept-encoding, x-rendering-proxy',
+    })
+  })
+
+  it('does not duplicate existing Vary values case-insensitively', () => {
+    expect(
+      appendVaryHeader(
+        {
+          Vary: 'Accept-Encoding, X-Rendering-Proxy',
+        },
+        'x-rendering-proxy',
+      ),
+    ).toStrictEqual({
+      Vary: 'Accept-Encoding, X-Rendering-Proxy',
+    })
+  })
+
+  it('leaves wildcard Vary unchanged', () => {
+    expect(appendVaryHeader({ vary: '*' }, 'x-rendering-proxy')).toStrictEqual({
+      vary: '*',
+    })
+  })
+})
 
 describe('excludeHopByHopHeaders', () => {
   it('returns headers excluded hop-by-hop header', () => {

--- a/src/lib/headers.ts
+++ b/src/lib/headers.ts
@@ -16,6 +16,54 @@ type Headers = {
   [key: string]: string
 }
 
+function findHeaderKey(headers: Headers, name: string): string | undefined {
+  return Object.keys(headers).find((key) => key.toLowerCase() === name)
+}
+
+function varyHeaderKey(headers: Headers): string {
+  return findHeaderKey(headers, 'vary') ?? 'vary'
+}
+
+function parseVaryValues(headers: Headers, varyKey: string): string[] {
+  return (headers[varyKey] ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+}
+
+function hasVaryValue(varyValues: string[], fieldName: string): boolean {
+  return varyValues.some(
+    (value) => value.toLowerCase() === fieldName.toLowerCase(),
+  )
+}
+
+function shouldKeepExistingVary(
+  varyValues: string[],
+  fieldName: string,
+): boolean {
+  return varyValues.includes('*') || hasVaryValue(varyValues, fieldName)
+}
+
+/**
+ * Append a request header name to Vary without dropping origin-provided Vary values.
+ * @param headers {Headers}
+ * @param fieldName {string}
+ * @returns headers {Headers}
+ */
+export function appendVaryHeader(headers: Headers, fieldName: string): Headers {
+  const varyKey = varyHeaderKey(headers)
+  const varyValues = parseVaryValues(headers, varyKey)
+
+  if (shouldKeepExistingVary(varyValues, fieldName)) {
+    return { ...headers }
+  }
+
+  return {
+    ...headers,
+    [varyKey]: [...varyValues, fieldName].join(', '),
+  }
+}
+
 /**
  * Note: Hop-by-hop headers are meaningful only for a single transport-level connection, and are not stored by caches or forwarded by proxies.
  * See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Compression#hop-by-hop_compression

--- a/src/server/index.spec.ts
+++ b/src/server/index.spec.ts
@@ -64,6 +64,7 @@ describe('withServer', () => {
       return res
     })
     expect(res.statusCode).toBe(200)
+    expect(res.headers.vary).toBe('x-rendering-proxy')
     expect(JSON.parse(res.read().toString('utf8'))).toStrictEqual({
       slideshow: {
         author: 'Yours Truly',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,7 @@ import type { Browser } from 'playwright'
 import { runWithDefer } from 'with-defer'
 
 import { getBrowser, type SelectableBrowsers } from '../browser'
-import { excludeUnusedHeaders } from '../lib/headers'
+import { appendVaryHeader, excludeUnusedHeaders } from '../lib/headers'
 import { isAbsoluteURL } from '../lib/url'
 import { waitForProcessExit } from '../lib/wait_for_exit'
 import { getRenderedContent } from '../render'
@@ -58,10 +58,13 @@ async function renderToResponse(
   request: Parameters<typeof getRenderedContent>[1],
 ): Promise<void> {
   const renderedContent = await getRenderedContent(browser, request)
-  const headers = {
-    ...excludeUnusedHeaders(renderedContent.headers),
-    'x-rendering-proxy': JSON.stringify(renderedContent.evaluateResults),
-  }
+  const headers = appendVaryHeader(
+    {
+      ...excludeUnusedHeaders(renderedContent.headers),
+      'x-rendering-proxy': JSON.stringify(renderedContent.evaluateResults),
+    },
+    'x-rendering-proxy',
+  )
   res.writeHead(renderedContent.status, headers)
   res.end(renderedContent.body, 'binary')
 }


### PR DESCRIPTION
Summary
- Add `X-Rendering-Proxy` to `Vary` while preserving existing `Vary` values.
- Cover the merge helper and server response behavior with tests.

Motivation
- Responses depend on `X-Rendering-Proxy` options, so shared caches need that header in `Vary`.

Test Plan
- `bun install --frozen-lockfile`
- `bun run format`
- `bun run lint`
- `bun run typecheck`
- `bunx vitest run src/lib/headers.spec.ts src/server/index.spec.ts --hookTimeout 30000 --testTimeout 30000`
- `bun run build`
- `bun run test`
- `bun pm pack`
- `bunx madge --circular --extensions ts,tsx src`

Note
- The local Docker workflow was not run locally because it requires Docker Compose browser containers; GitHub CI will cover it.
