### PR TITLE
fix: cap concurrent renders and evaluates array length

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,16 @@ import { cli, server } from './'
 import { type SelectableBrowsers, selectableBrowsers } from './browser'
 import { type LifecycleEvent, lifeCycleEvents } from './render'
 
+function validateMaxConcurrentRenders(argv: {
+  'max-concurrent-renders': unknown
+}): true {
+  const m = argv['max-concurrent-renders'] as number
+  if (!Number.isInteger(m) || m < 0) {
+    throw new Error('--max-concurrent-renders must be a non-negative integer')
+  }
+  return true
+}
+
 export async function main(): Promise<void> {
   yargs(process.argv.slice(2))
     .command(
@@ -65,11 +75,19 @@ export async function main(): Promise<void> {
             choices: selectableBrowsers,
             default: 'chromium',
           })
+          .option('max-concurrent-renders', {
+            alias: 'm',
+            type: 'number',
+            description: 'Maximum number of concurrent render requests',
+            default: 10,
+          })
+          .check(validateMaxConcurrentRenders)
       },
       async (argv) => {
         await server.main({
           port: argv.port,
           name: argv.browser as SelectableBrowsers,
+          maxConcurrentRenders: argv['max-concurrent-renders'] as number,
         })
       },
     )

--- a/src/server/index.spec.ts
+++ b/src/server/index.spec.ts
@@ -148,4 +148,71 @@ describe('withServer', () => {
     expect(res.statusCode).toBe(200)
     expect(res.read().toString('utf8')).toBe('OK')
   })
+
+  it('responses 503 when concurrent render limit is exceeded', async () => {
+    const port = 8093
+    const res = await runWithDefer(async (defer) => {
+      const browser = await getBrowser()
+      defer(() => browser.close())
+
+      const server = await createServer({
+        browser,
+        port,
+        maxConcurrentRenders: 0,
+      })
+      defer(() => server.close())
+
+      const res: IncomingMessage = await new Promise((resolve) => {
+        return http.get(`http://localhost:${port}/${httpbinUrl}/json`, (res) =>
+          resolve(res),
+        )
+      })
+      return res
+    })
+    expect(res.statusCode).toBe(503)
+  })
+
+  it('health check bypasses concurrent render limit', async () => {
+    const port = 8094
+    const res = await runWithDefer(async (defer) => {
+      const browser = await getBrowser()
+      defer(() => browser.close())
+
+      const server = await createServer({
+        browser,
+        port,
+        maxConcurrentRenders: 0,
+      })
+      defer(() => server.close())
+
+      const res: IncomingMessage = await new Promise((resolve) => {
+        return http.get(`http://localhost:${port}/health/`, (res) =>
+          resolve(res),
+        )
+      })
+      return res
+    })
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('invalid URL bypasses concurrent render limit', async () => {
+    const port = 8095
+    const res = await runWithDefer(async (defer) => {
+      const browser = await getBrowser()
+      defer(() => browser.close())
+
+      const server = await createServer({
+        browser,
+        port,
+        maxConcurrentRenders: 0,
+      })
+      defer(() => server.close())
+
+      const res: IncomingMessage = await new Promise((resolve) => {
+        return http.get(`http://localhost:${port}/`, (res) => resolve(res))
+      })
+      return res
+    })
+    expect(res.statusCode).toBe(204)
+  })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,6 +15,7 @@ interface ServerArgument {
   port?: number
   name?: SelectableBrowsers
   headless?: boolean
+  maxConcurrentRenders?: number
 }
 
 type IncomingRenderRequest =
@@ -108,25 +109,63 @@ function replyWithBadGateway(res: http.ServerResponse): void {
   }
 }
 
-export function createHandler(browser: Browser) {
+async function renderWithConcurrencyLimit(
+  browser: Browser,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  counter: { value: number },
+  limit: number,
+): Promise<void> {
+  if (counter.value >= limit) {
+    res.writeHead(503, { 'retry-after': '1' })
+    res.end()
+    return
+  }
+  counter.value++
+  try {
+    await respondToIncomingRequest(browser, req, res)
+  } finally {
+    counter.value--
+  }
+}
+
+export function createHandler(
+  browser: Browser,
+  { maxConcurrentRenders = 10 }: { maxConcurrentRenders?: number } = {},
+) {
+  const counter = { value: 0 }
+
   return function renderHandler(
     req: http.IncomingMessage,
     res: http.ServerResponse,
   ) {
-    respondToIncomingRequest(browser, req, res).catch(() =>
-      replyWithBadGateway(res),
-    )
+    const parsedRequest = parseIncomingRenderRequest(req)
+    const task =
+      parsedRequest.type === 'render'
+        ? renderWithConcurrencyLimit(
+            browser,
+            req,
+            res,
+            counter,
+            maxConcurrentRenders,
+          )
+        : respondToIncomingRequest(browser, req, res)
+    task.catch(() => replyWithBadGateway(res))
   }
 }
 
 export async function createServer({
   browser,
   port = 8080,
+  maxConcurrentRenders = 10,
 }: {
   browser: Browser
   port: number
+  maxConcurrentRenders?: number
 }): Promise<http.Server> {
-  const server = http.createServer(createHandler(browser))
+  const server = http.createServer(
+    createHandler(browser, { maxConcurrentRenders }),
+  )
   await new Promise((resolve) => {
     server.listen(port, () => {
       resolve(undefined)
@@ -167,12 +206,13 @@ export async function main({
   port = 8080,
   name = 'chromium',
   headless = true,
+  maxConcurrentRenders = 10,
 }: ServerArgument = {}): Promise<void> {
   await runWithDefer(async (defer) => {
     const browser = await getBrowser({ name, headless })
     defer(() => browser.close())
 
-    const server = await createServer({ browser, port })
+    const server = await createServer({ browser, port, maxConcurrentRenders })
     defer(() => closeServerGracefully(server))
 
     await waitForProcessExit()

--- a/src/server/request_options.spec.ts
+++ b/src/server/request_options.spec.ts
@@ -109,4 +109,13 @@ describe('parseRenderingProxyHeader', () => {
       timeout: undefined,
     })
   })
+
+  it('truncates evaluates to at most 10 entries', async () => {
+    const scripts = Array.from({ length: 20 }, (_, i) => `script${i}`)
+    const result = parseRenderingProxyHeader(
+      JSON.stringify({ evaluates: scripts }),
+    )
+    expect(result.evaluates).toHaveLength(10)
+    expect(result.evaluates).toStrictEqual(scripts.slice(0, 10))
+  })
 })

--- a/src/server/request_options.ts
+++ b/src/server/request_options.ts
@@ -32,10 +32,16 @@ function normalizeWaitUntil(value: unknown): LifecycleEvent {
     : 'load'
 }
 
+const MAX_EVALUATES = 10
+
 function normalizeEvaluates(value: unknown): string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === 'string')
-    ? value
-    : []
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === 'string')
+  ) {
+    return []
+  }
+  return value.slice(0, MAX_EVALUATES)
 }
 
 function normalizeTimeout(value: unknown): number | undefined {


### PR DESCRIPTION
## Summary

- Add `maxConcurrentRenders` option (default 10) to `createServer`, `createHandler`, and `server main`. Render requests beyond the cap receive HTTP 503 with `Retry-After: 1`; health and invalid-URL requests bypass the limit.
- Add `MAX_EVALUATES = 10` in `request_options.ts` to truncate the `evaluates` array, bounding the `x-rendering-proxy` response header size.
- Expose `--max-concurrent-renders` / `-m` CLI flag with non-negative integer validation.

## Changes

### `src/server/index.ts`
- Extract `renderWithConcurrencyLimit()` — checks the counter, returns 503 if at limit, otherwise increments, delegates to `respondToIncomingRequest`, and decrements in `finally`.
- `createHandler` now accepts `{ maxConcurrentRenders?: number }` and owns a `{ value: number }` counter shared across requests.
- `createServer` and `main` accept `maxConcurrentRenders` and forward it to `createHandler`.

### `src/server/request_options.ts`
- `normalizeEvaluates` now slices the array to `MAX_EVALUATES` (10) entries.

### `src/main.ts`
- Add `--max-concurrent-renders` / `-m` option with `.check(validateMaxConcurrentRenders)` to reject non-integer or negative values.

### `src/server/index.spec.ts`
- Test: render request receives 503 when `maxConcurrentRenders: 0`.
- Test: `/health/` returns 200 even when `maxConcurrentRenders: 0`.
- Test: invalid URL (`/`) returns 204 even when `maxConcurrentRenders: 0`.

### `src/server/request_options.spec.ts`
- Test: `evaluates` array with 20 entries is truncated to 10.

## Verification

- `bun run format` — no issues
- `bun run lint` — no issues
- `bun run typecheck` — no issues
- `bunx vitest run src/server/request_options.spec.ts` — 4 passed
- `bunx madge --circular --extensions ts,tsx src` — no circular dependencies

The new integration tests (503 and health bypass) require a live browser and run under `bun run test` in CI.

## Trade-offs

- **Counter vs. queue**: the counter approach rejects at 503 immediately rather than queuing. Callers get a fast, retry-able response instead of accumulating memory. If queuing is preferred in future, this can be replaced with a semaphore.
- **Evaluates truncation**: silently drops scripts beyond position 10. No error is returned so callers are unaware. This is acceptable given that the header is caller-controlled input; future work could add a warning in the response.
- **Double parse**: `parseIncomingRenderRequest` is called twice for render requests (once in `createHandler` and once inside `respondToIncomingRequest`). This is a pre-existing pattern; the overhead is negligible and a refactor is deferred.