### PR TITLE
fix: handle SIGTERM and SIGINT for graceful shutdown

### DIFF
--- a/src/lib/wait_for_exit.spec.ts
+++ b/src/lib/wait_for_exit.spec.ts
@@ -1,25 +1,19 @@
-import { describe, expect, it, vi } from 'vitest'
-// waitForProcessExit
+import { describe, it } from 'vitest'
+
 import { waitForProcessExit } from './wait_for_exit'
 
 describe('waitForProcessExit', () => {
-  let called = false
-
-  type MockType = (code?: string | number | null | undefined) => never
-  const spy = vi.spyOn(process, 'exit').mockImplementation(((
-    code?: string | number | null | undefined,
-  ) => {
-    called = true
-    process.emit('exit', code ?? 0)
-  }) as MockType)
-
-  it('wait for process.exit', async () => {
+  it('resolves when SIGTERM is received', async () => {
     setTimeout(() => {
-      process.exit(0)
-    }, 200)
-    expect(called).toBe(false)
+      process.emit('SIGTERM')
+    }, 50)
     await waitForProcessExit()
-    expect(called).toBe(true)
-    spy.mockClear()
+  })
+
+  it('resolves when SIGINT is received', async () => {
+    setTimeout(() => {
+      process.emit('SIGINT')
+    }, 50)
+    await waitForProcessExit()
   })
 })

--- a/src/lib/wait_for_exit.ts
+++ b/src/lib/wait_for_exit.ts
@@ -1,5 +1,11 @@
 export async function waitForProcessExit() {
-  await new Promise((resolve) => {
-    process.on('exit', resolve)
+  await new Promise<void>((resolve) => {
+    const onSignal = () => {
+      process.off('SIGTERM', onSignal)
+      process.off('SIGINT', onSignal)
+      resolve()
+    }
+    process.once('SIGTERM', onSignal)
+    process.once('SIGINT', onSignal)
   })
 }


### PR DESCRIPTION
## Summary

- Replace `process.on('exit', resolve)` in `waitForProcessExit` with `SIGTERM` and `SIGINT` handlers.
- The `exit` event fires after the event loop is already winding down; async deferred cleanup (`browser.close`, `server.close`) cannot complete at that point.
- Signal handlers keep the event loop alive so `runWithDefer` cleanup runs to completion before the process exits.

## Changes

### `src/lib/wait_for_exit.ts`

```
// before
process.on('exit', resolve)

// after
const onSignal = () => {
  process.off('SIGTERM', onSignal)
  process.off('SIGINT', onSignal)
  resolve()
}
process.once('SIGTERM', onSignal)
process.once('SIGINT', onSignal)
```

Using a shared `onSignal` handler removes both listeners when either signal fires, avoiding a lingering listener after cleanup.

### `src/lib/wait_for_exit.spec.ts`

Replace the mock-based `process.exit` test with two direct tests using `process.emit('SIGTERM')` and `process.emit('SIGINT')`.

## Verification

- `bun run format` — no issues
- `bun run typecheck` — no issues
- `bunx vitest run src/lib/wait_for_exit.spec.ts` — 2 passed
- `bunx madge --circular --extensions ts,tsx src` — no circular dependencies

## Trade-offs

- This does not add a timeout for cleanup; if `browser.close()` hangs, the process will not exit. A future improvement could add a `setTimeout` fallback that calls `process.exit(1)` if cleanup takes too long.
- Only `SIGTERM` and `SIGINT` are handled. Other termination signals (e.g. `SIGHUP`) are not. This covers the primary container-stop (`docker stop` → SIGTERM) and keyboard interrupt (Ctrl-C → SIGINT) use cases.