### PR TITLE
fix: isolate browser context per render request

### DIFF
--- a/src/render/index.spec.ts
+++ b/src/render/index.spec.ts
@@ -83,7 +83,7 @@ describe('getRenderedContent', () => {
     const dom = cheerioLoad(result.body.toString('utf8'))
     expect(dom('h1.title').text()).toEqual('Hello, rendering-proxy!')
     expect(dom('.factorial').text()).toEqual('factorial(5) = 120')
-    expect(browser.contexts.length).toBe(0)
+    expect(browser.contexts().length).toBe(0)
   })
 
   it('responses rendered Vue', async () => {
@@ -94,7 +94,7 @@ describe('getRenderedContent', () => {
     const dom = cheerioLoad(result.body.toString('utf8'))
     expect(dom('h1.title').text()).toEqual('Hello, rendering-proxy!')
     expect(dom('.fibonacci').text()).toEqual('fibonacci(10) = 55')
-    expect(browser.contexts.length).toBe(0)
+    expect(browser.contexts().length).toBe(0)
   })
 
   it('can handle empty response', async () => {
@@ -103,7 +103,7 @@ describe('getRenderedContent', () => {
     })
     expect(result.status).toEqual(204)
     expect(result.body.byteLength).toBe(0)
-    expect(browser.contexts.length).toBe(0)
+    expect(browser.contexts().length).toBe(0)
   })
 
   test('image/png', async () => {
@@ -216,5 +216,32 @@ describe('getRenderedContent with evaluates', () => {
       'document.title = "Updated Title"',
     )
     expect(result.evaluateResults[0].result).toBe('Updated Title')
+  })
+
+  it('isolates browser storage between render requests', async () => {
+    const setterResult = await getRenderedContent(browser, {
+      url: 'http://localhost:8004/test.html',
+      evaluates: [
+        'document.cookie = "render_proxy_test=leaked; path=/"',
+        'localStorage.setItem("render_proxy_test", "leaked")',
+        'sessionStorage.setItem("render_proxy_test", "leaked")',
+      ],
+    })
+    expect(setterResult.status).toBe(200)
+
+    const result = await getRenderedContent(browser, {
+      url: 'http://localhost:8004/test.html',
+      evaluates: [
+        'document.cookie',
+        'localStorage.getItem("render_proxy_test")',
+        'sessionStorage.getItem("render_proxy_test")',
+      ],
+    })
+
+    expect(result.evaluateResults.map(({ result }) => result)).toEqual([
+      '',
+      null,
+      null,
+    ])
   })
 })

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,4 +1,4 @@
-import type { Browser, Response as PlaywrightResponse } from 'playwright'
+import type { Browser, Page, Response as PlaywrightResponse } from 'playwright'
 import { runWithDefer } from 'with-defer'
 
 export const lifeCycleEvents = [
@@ -46,7 +46,7 @@ function isRenderableContentType(contentType: string): boolean {
 }
 
 async function evaluateScript(
-  page: Awaited<ReturnType<Browser['newPage']>>,
+  page: Page,
   script: string,
   waitUntil: LifecycleEvent,
 ): Promise<EvaluateResult> {
@@ -63,7 +63,7 @@ async function evaluateScript(
 }
 
 async function collectEvaluateResults(
-  page: Awaited<ReturnType<Browser['newPage']>>,
+  page: Page,
   evaluates: string[] | undefined,
   waitUntil: LifecycleEvent,
 ): Promise<EvaluateResult[]> {
@@ -73,7 +73,7 @@ async function collectEvaluateResults(
 }
 
 async function navigatePage(
-  page: Awaited<ReturnType<Browser['newPage']>>,
+  page: Page,
   request: Required<Pick<RenderRequest, 'url' | 'waitUntil'>> & RenderRequest,
 ): Promise<{
   response: PlaywrightResponse | null
@@ -98,7 +98,7 @@ async function navigatePage(
 }
 
 async function readRenderedBody(
-  page: Awaited<ReturnType<Browser['newPage']>>,
+  page: Page,
   response: PlaywrightResponse,
 ): Promise<Buffer> {
   const headers = { ...response.headers() }
@@ -118,8 +118,9 @@ export async function getRenderedContent(
   }
 
   return await runWithDefer(async (defer) => {
-    const page = await browser.newPage()
-    defer(() => page.close())
+    const context = await browser.newContext()
+    defer(() => context.close())
+    const page = await context.newPage()
 
     const navigationResult = await navigatePage(page, normalizedRequest)
     if (!navigationResult?.response) {


### PR DESCRIPTION
## Summary
Render requests now create a fresh Playwright browser context before opening a page, and close it through the existing defer flow. Tests cover cookie/localStorage/sessionStorage isolation and assert contexts are closed.

## Verification
- `bun install --frozen-lockfile`
- `bun run format`
- `bun run lint`
- `bun run typecheck`
- `bunx vitest run src/render/index.spec.ts --hookTimeout 30000 --testTimeout 30000`
- `bun run build`
- `bun run test`
- `bun pm pack`
- `bunx madge --circular --extensions ts,tsx src`
- `git diff --check`
