### PR TITLE
fix: remove spurious waitUntil arg from page.evaluate

### DIFF
--- a/src/render/index.spec.ts
+++ b/src/render/index.spec.ts
@@ -265,4 +265,17 @@ describe('getRenderedContent with evaluates', () => {
       null,
     ])
   })
+
+  it('does not inject unexpected arguments into function-form scripts', async () => {
+    // Regression guard: page.evaluate must not receive a second argument.
+    // Before the fix, { waitUntil } was passed as arg, so '(arg) => typeof arg'
+    // would return 'object'. Without an injected arg, Playwright returns undefined
+    // because the function expression is not invocable without an arg.
+    const result = await getRenderedContent(browser, {
+      url: 'http://localhost:8004/test.html',
+      evaluates: ['(arg) => typeof arg'],
+    })
+    expect(result.evaluateResults[0].success).toBe(true)
+    expect(result.evaluateResults[0].result).toBeUndefined()
+  })
 })

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -47,10 +47,9 @@ function isRenderableContentType(contentType: string): boolean {
 async function evaluateScript(
   page: Page,
   script: string,
-  waitUntil: LifecycleEvent,
 ): Promise<EvaluateResult> {
   try {
-    const result = await page.evaluate(script, { waitUntil })
+    const result = await page.evaluate(script)
     return { success: true, result, script }
   } catch (error) {
     return {
@@ -64,10 +63,9 @@ async function evaluateScript(
 async function collectEvaluateResults(
   page: Page,
   evaluates: string[] | undefined,
-  waitUntil: LifecycleEvent,
 ): Promise<EvaluateResult[]> {
   return Promise.all(
-    (evaluates ?? []).map((script) => evaluateScript(page, script, waitUntil)),
+    (evaluates ?? []).map((script) => evaluateScript(page, script)),
   )
 }
 
@@ -86,7 +84,6 @@ async function navigatePage(
     const evaluateResults = await collectEvaluateResults(
       page,
       request.evaluates,
-      request.waitUntil,
     )
     return {
       response,


### PR DESCRIPTION
## Summary

`page.evaluate(pageFunction, arg?)` passes `arg` to the page function as an argument — it has no effect on evaluation timing. The `waitUntil` value was being forwarded from `evaluateScript`/`collectEvaluateResults` into `page.evaluate` as a second argument, which:

1. Has no effect on when evaluation happens (`page.goto({ waitUntil })` already controls that)
2. Leaks `{ waitUntil: 'load' }` into scripts that use function-argument form (e.g. `(arg) => arg.x`)

The existing tests only use expression strings (`'document.title'`, `'1 + 1'`), which silently absorb a spurious arg, so the bug was not visible.

## Changes

- `evaluateScript`: removed `waitUntil` parameter; call `page.evaluate(script)` instead of `page.evaluate(script, { waitUntil })`
- `collectEvaluateResults`: removed `waitUntil` parameter (no longer passed to `evaluateScript`)
- Added regression test: a function-form script `(arg) => typeof arg` must not receive an injected argument (expected: `undefined`, would be `'object'` with the old code)

## Verification

All 36 tests pass. `madge --circular` reports 0 circular dependencies.