### PR TITLE
feat: add configurable timeout to navigation

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -13,6 +13,7 @@ export interface RenderRequest {
   url: string
   waitUntil?: LifecycleEvent
   evaluates?: string[]
+  timeout?: number
 }
 
 export interface EvaluateResult {
@@ -82,6 +83,7 @@ async function navigatePage(
   try {
     const response = await page.goto(request.url, {
       waitUntil: request.waitUntil,
+      timeout: request.timeout,
     })
     const evaluateResults = await collectEvaluateResults(
       page,

--- a/src/server/request_options.spec.ts
+++ b/src/server/request_options.spec.ts
@@ -7,28 +7,34 @@ describe('parseRenderingProxyHeader', () => {
     expect(parseRenderingProxyHeader(undefined)).toStrictEqual({
       waitUntil: 'load',
       evaluates: [],
+      timeout: undefined,
     })
     expect(parseRenderingProxyHeader('')).toStrictEqual({
       waitUntil: 'load',
       evaluates: [],
+      timeout: undefined,
     })
     expect(parseRenderingProxyHeader([])).toStrictEqual({
       waitUntil: 'load',
       evaluates: [],
+      timeout: undefined,
     })
     expect(parseRenderingProxyHeader('1234')).toStrictEqual({
       waitUntil: 'load',
       evaluates: [],
+      timeout: undefined,
     })
     expect(parseRenderingProxyHeader('{')).toStrictEqual({
       waitUntil: 'load',
       evaluates: [],
+      timeout: undefined,
     })
     expect(
       parseRenderingProxyHeader('{"evaluates": 1234, "waitUntil": 3456}'),
     ).toStrictEqual({
       waitUntil: 'load',
       evaluates: [],
+      timeout: undefined,
     })
   })
 
@@ -36,11 +42,13 @@ describe('parseRenderingProxyHeader', () => {
     expect(parseRenderingProxyHeader('{"evaluates": []}')).toStrictEqual({
       waitUntil: 'load',
       evaluates: [],
+      timeout: undefined,
     })
     expect(parseRenderingProxyHeader('{"evaluates": ["1 + 1"]}')).toStrictEqual(
       {
         waitUntil: 'load',
         evaluates: ['1 + 1'],
+        timeout: undefined,
       },
     )
     expect(
@@ -48,6 +56,7 @@ describe('parseRenderingProxyHeader', () => {
     ).toStrictEqual({
       waitUntil: 'load',
       evaluates: ['1 + 1', 'document.title'],
+      timeout: undefined,
     })
   })
 
@@ -57,20 +66,47 @@ describe('parseRenderingProxyHeader', () => {
     ).toStrictEqual({
       waitUntil: 'networkidle',
       evaluates: [],
+      timeout: undefined,
     })
     expect(
       parseRenderingProxyHeader('{"waitUntil": "domcontentloaded"}'),
     ).toStrictEqual({
       waitUntil: 'domcontentloaded',
       evaluates: [],
+      timeout: undefined,
     })
     expect(parseRenderingProxyHeader('{"waitUntil": "load"}')).toStrictEqual({
       waitUntil: 'load',
       evaluates: [],
+      timeout: undefined,
     })
     expect(parseRenderingProxyHeader('{"waitUntil": "commit"}')).toStrictEqual({
       waitUntil: 'commit',
       evaluates: [],
+      timeout: undefined,
+    })
+  })
+
+  it('parses timeout', async () => {
+    expect(parseRenderingProxyHeader('{"timeout": 5000}')).toStrictEqual({
+      waitUntil: 'load',
+      evaluates: [],
+      timeout: 5000,
+    })
+    expect(parseRenderingProxyHeader('{"timeout": 0}')).toStrictEqual({
+      waitUntil: 'load',
+      evaluates: [],
+      timeout: undefined,
+    })
+    expect(parseRenderingProxyHeader('{"timeout": -1}')).toStrictEqual({
+      waitUntil: 'load',
+      evaluates: [],
+      timeout: undefined,
+    })
+    expect(parseRenderingProxyHeader('{"timeout": "fast"}')).toStrictEqual({
+      waitUntil: 'load',
+      evaluates: [],
+      timeout: undefined,
     })
   })
 })

--- a/src/server/request_options.ts
+++ b/src/server/request_options.ts
@@ -3,6 +3,7 @@ import { type LifecycleEvent, lifeCycleEvents } from '../render'
 interface RequestOption {
   waitUntil: LifecycleEvent
   evaluates: string[]
+  timeout: number | undefined
 }
 
 export function parseRenderingProxyHeader(
@@ -37,11 +38,16 @@ function normalizeEvaluates(value: unknown): string[] {
     : []
 }
 
+function normalizeTimeout(value: unknown): number | undefined {
+  return typeof value === 'number' && value > 0 ? value : undefined
+}
+
 function parseOptions(text: string): RequestOption {
   const baseParsed = tryParseOptions(text) as Partial<RequestOption> | null
 
   return {
     waitUntil: normalizeWaitUntil(baseParsed?.waitUntil),
     evaluates: normalizeEvaluates(baseParsed?.evaluates),
+    timeout: normalizeTimeout(baseParsed?.timeout),
   }
 }


### PR DESCRIPTION
## Summary

`page.goto()` was called without an explicit `timeout` option, making Playwright's 30-second default the only available timeout. Slow external sites would always consume the full 30 seconds regardless of the desired SLA, and there was no way for callers — via CLI or HTTP header — to control this.

## Changes

- Add `timeout?: number` field to `RenderRequest` interface
- Add `timeout: number | undefined` to `RequestOption` (parsed from `x-rendering-proxy` header)
- Add `normalizeTimeout` validator: accepts positive integers, rejects zero, negative, and non-number values
- Pass `timeout: request.timeout` to `page.goto()`
- Update tests: add `timeout: undefined` to all existing expected results and add a `parses timeout` test suite

When `timeout` is omitted or invalid, Playwright's default (30 seconds) still applies — no behaviour change for existing consumers.

## Verification

```sh
bun run typecheck   # tsc --noEmit — no errors
bun run lint        # biome check — 30 files, 0 issues
bun run test        # 36 tests pass
```

## Usage

```json
{
  "timeout": 5000
}
```

Pass as the `x-rendering-proxy` header value. A positive integer sets the navigation timeout in milliseconds; 0, negative, or a non-number value falls back to Playwright's default.
