### PR TITLE
feat: add access log and navigation error log

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -92,7 +92,8 @@ async function navigatePage(
       response,
       evaluateResults,
     }
-  } catch {
+  } catch (error) {
+    console.error(`navigate failed: ${request.url}`, error)
     return null
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -72,6 +72,7 @@ async function respondToIncomingRequest(
   res: http.ServerResponse,
 ): Promise<void> {
   const parsedRequest = parseIncomingRenderRequest(req)
+  const startMs = Date.now()
   const handlers: Record<IncomingRenderRequest['type'], () => Promise<void>> = {
     health: async () => {
       res.writeHead(200)
@@ -89,6 +90,12 @@ async function respondToIncomingRequest(
   }
 
   await handlers[parsedRequest.type]()
+
+  if (parsedRequest.type === 'render') {
+    console.log(
+      `render ${parsedRequest.request.url} ${res.statusCode} ${Date.now() - startMs}ms`,
+    )
+  }
 }
 
 export function createHandler(browser: Browser) {


### PR DESCRIPTION
## Summary

The rendering-proxy server emitted no log output at all — no access log, no error log. A navigation failure was indistinguishable from a normal 204 response, and there was no record of which URLs were requested, their status codes, or how long they took. Operators had no signal to detect errors or performance regressions.

## Changes

**`src/server/index.ts`**
- In `respondToIncomingRequest`, record `startMs = Date.now()` before dispatching.
- After the handler completes, emit one access-log line to stdout per render request:
  `render <url> <statusCode> <durationMs>ms`

**`src/render/index.ts`**
- In the `navigatePage` catch block, bind the caught error to `error` and emit it to stderr:
  `navigate failed: <url> <error>`

Health and invalid-URL requests are not logged (no URL to record for health; `terminateRequestWithEmpty` already handles the invalid case).

## Verification

```sh
bun run typecheck   # tsc --noEmit — no errors
bun run lint        # biome check — 30 files, 0 issues
bun run test        # 35 tests pass
```

## Trade-offs

- Structured logging (pino/winston) and request timing in the render layer are left out of scope; this PR adds the minimum observable signal at the server boundary.
- Each render produces one stdout line; health and invalid requests produce none (intentional).
