### PR TITLE
fix: restart browser automatically on disconnect in server mode

### DIFF
--- a/src/server/index.spec.ts
+++ b/src/server/index.spec.ts
@@ -93,7 +93,7 @@ describe('withServer', () => {
       const browser = await getBrowser()
       defer(() => browser.close())
 
-      const server = await createServer({ browser, port })
+      const server = await createServer({ getBrowserFn: () => browser, port })
       defer(() => server.close())
 
       const res: IncomingMessage = await new Promise((resolve) => {
@@ -137,7 +137,7 @@ describe('withServer', () => {
       const browser = await getBrowser()
       defer(() => browser.close())
 
-      const server = await createServer({ browser, port })
+      const server = await createServer({ getBrowserFn: () => browser, port })
       defer(() => server.close())
 
       const res: IncomingMessage = await new Promise((resolve) => {
@@ -153,7 +153,7 @@ describe('withServer', () => {
   it('returns 502 when browser becomes unavailable', async () => {
     const port = 8093
     const browser = await getBrowser()
-    const server = await createServer({ browser, port })
+    const server = await createServer({ getBrowserFn: () => browser, port })
 
     try {
       await browser.close()
@@ -178,7 +178,7 @@ describe('withServer', () => {
       const browser = await getBrowser()
       defer(() => browser.close())
 
-      const server = await createServer({ browser, port })
+      const server = await createServer({ getBrowserFn: () => browser, port })
       defer(() => server.close())
 
       const res: IncomingMessage = await new Promise((resolve) => {
@@ -199,7 +199,7 @@ describe('withServer', () => {
       defer(() => browser.close())
 
       const server = await createServer({
-        browser,
+        getBrowserFn: () => browser,
         port,
         maxConcurrentRenders: 0,
       })
@@ -222,7 +222,7 @@ describe('withServer', () => {
       defer(() => browser.close())
 
       const server = await createServer({
-        browser,
+        getBrowserFn: () => browser,
         port,
         maxConcurrentRenders: 0,
       })
@@ -245,7 +245,7 @@ describe('withServer', () => {
       defer(() => browser.close())
 
       const server = await createServer({
-        browser,
+        getBrowserFn: () => browser,
         port,
         maxConcurrentRenders: 0,
       })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -126,7 +126,7 @@ function replyWithBadGateway(res: http.ServerResponse): void {
 }
 
 async function renderWithConcurrencyLimit(
-  browser: Browser,
+  getBrowserFn: () => Browser,
   req: http.IncomingMessage,
   res: http.ServerResponse,
   counter: { value: number },
@@ -139,18 +139,17 @@ async function renderWithConcurrencyLimit(
   }
   counter.value++
   try {
-    await respondToIncomingRequest(browser, req, res)
+    await respondToIncomingRequest(getBrowserFn(), req, res)
   } finally {
     counter.value--
   }
 }
 
 export function createHandler(
-  browser: Browser,
+  getBrowserFn: () => Browser,
   { maxConcurrentRenders = 10 }: { maxConcurrentRenders?: number } = {},
 ) {
   const counter = { value: 0 }
-
   return function renderHandler(
     req: http.IncomingMessage,
     res: http.ServerResponse,
@@ -159,28 +158,28 @@ export function createHandler(
     const task =
       parsedRequest.type === 'render'
         ? renderWithConcurrencyLimit(
-            browser,
+            getBrowserFn,
             req,
             res,
             counter,
             maxConcurrentRenders,
           )
-        : respondToIncomingRequest(browser, req, res)
+        : respondToIncomingRequest(getBrowserFn(), req, res)
     task.catch(() => replyWithBadGateway(res))
   }
 }
 
 export async function createServer({
-  browser,
+  getBrowserFn,
   port = 8080,
   maxConcurrentRenders = 10,
 }: {
-  browser: Browser
+  getBrowserFn: () => Browser
   port: number
   maxConcurrentRenders?: number
 }): Promise<http.Server> {
   const server = http.createServer(
-    createHandler(browser, { maxConcurrentRenders }),
+    createHandler(getBrowserFn, { maxConcurrentRenders }),
   )
   await new Promise((resolve) => {
     server.listen(port, () => {
@@ -225,10 +224,28 @@ export async function main({
   maxConcurrentRenders = 10,
 }: ServerArgument = {}): Promise<void> {
   await runWithDefer(async (defer) => {
-    const browser = await getBrowser({ name, headless })
-    defer(() => browser.close())
+    let activeBrowser = await getBrowser({ name, headless })
 
-    const server = await createServer({ browser, port, maxConcurrentRenders })
+    const onDisconnected = async () => {
+      try {
+        activeBrowser = await getBrowser({ name, headless })
+        activeBrowser.on('disconnected', onDisconnected)
+      } catch {
+        // Restart failed; subsequent requests will error naturally
+      }
+    }
+    activeBrowser.on('disconnected', onDisconnected)
+
+    defer(async () => {
+      activeBrowser.removeListener('disconnected', onDisconnected)
+      await activeBrowser.close()
+    })
+
+    const server = await createServer({
+      getBrowserFn: () => activeBrowser,
+      port,
+      maxConcurrentRenders,
+    })
     defer(() => closeServerGracefully(server))
 
     await waitForProcessExit()


### PR DESCRIPTION
## Summary

- The server's `main()` shared one Playwright `Browser` instance across all requests with no recovery path when it disconnected (OOM, runtime crash, Playwright error). Once dead, every request returned 502 until a manual server restart.
- Added a `'disconnected'` event listener on the browser that automatically restarts it and re-registers the listener. The server handler reads the current browser through a `() => Browser` getter closure, so the new instance takes effect without restarting the HTTP server.
- `createHandler` and `createServer` now accept a `getBrowserFn: () => Browser` parameter instead of a direct `Browser` instance, enabling the mutable reference to propagate on reconnect.

## Changed files

- `src/server/index.ts` — browser auto-restart logic in `main()`, updated `createHandler`/`createServer` signatures
- `src/server/index.spec.ts` — updated test callsites to pass `getBrowserFn: () => browser`

## Test plan

- [ ] `npx tsc --noEmit` — type-checks pass
- [ ] `npx biome check .` — no lint errors
- [ ] `npx vitest run src/lib/headers.spec.ts src/index.spec.ts` — unit tests pass
- [ ] Integration tests `src/server/index.spec.ts` — server still responds correctly via the new `getBrowserFn` API

## Trade-offs

- **Restart race**: if `getBrowser()` throws during a restart attempt, the error is swallowed and subsequent requests will fail until the next disconnect fires. This keeps the server alive but may silently delay recovery. A future improvement could add a retry loop or health-check endpoint that reflects browser state.
- **API change**: `createServer({ browser })` → `createServer({ getBrowserFn })` is a breaking change for direct callers of `createServer`; all in-repo usages have been updated.