### PR TITLE
fix: strip origin-bound security headers before forwarding to client

### DIFF
--- a/src/lib/headers.spec.ts
+++ b/src/lib/headers.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   excludeContentDependentHeaders,
   excludeHopByHopHeaders,
+  excludeOriginSecurityContextHeaders,
   excludeUnusedHeaders,
 } from './headers'
 
@@ -34,6 +35,44 @@ describe('excludeContentDependentHeaders', () => {
   })
 })
 
+describe('excludeOriginSecurityContextHeaders', () => {
+  it('strips origin-bound security headers', () => {
+    expect(excludeOriginSecurityContextHeaders({})).toStrictEqual({})
+    expect(
+      excludeOriginSecurityContextHeaders({
+        'set-cookie': 'session=abc; Path=/',
+        'strict-transport-security': 'max-age=31536000',
+        'content-security-policy': "default-src 'self'",
+        'content-security-policy-report-only': "default-src 'self'",
+        'access-control-allow-origin': '*',
+        'access-control-allow-credentials': 'true',
+        'access-control-allow-methods': 'GET, POST',
+        'access-control-allow-headers': 'Content-Type',
+        'access-control-expose-headers': 'X-Custom',
+        'access-control-max-age': '600',
+        'clear-site-data': '"cache","cookies"',
+        etag: '"3147526947"',
+      }),
+    ).toStrictEqual({
+      etag: '"3147526947"',
+    })
+  })
+
+  it('passes through unrelated headers', () => {
+    expect(
+      excludeOriginSecurityContextHeaders({
+        etag: '"abc"',
+        'content-type': 'text/html',
+        'x-custom': 'value',
+      }),
+    ).toStrictEqual({
+      etag: '"abc"',
+      'content-type': 'text/html',
+      'x-custom': 'value',
+    })
+  })
+})
+
 describe('excludeUnusedHeaders', () => {
   it('returns headers excluded that unused by rendering-proxy', () => {
     expect(excludeUnusedHeaders({})).toStrictEqual({})
@@ -41,6 +80,7 @@ describe('excludeUnusedHeaders', () => {
       excludeUnusedHeaders({
         connection: 'Keep-Alive',
         'content-encoding': 'gzip',
+        'set-cookie': 'session=abc',
         etag: '"3147526947"',
       }),
     ).toStrictEqual({

--- a/src/lib/headers.ts
+++ b/src/lib/headers.ts
@@ -12,6 +12,24 @@ const hopByHopHeaders = [
 
 const contentDependentHeaders = ['content-encoding', 'content-length']
 
+// Security headers that are bound to the origin's domain context.
+// Forwarding them to the proxy client would allow a malicious origin to
+// set cookies, HSTS policies, CSP directives, or CORS permissions on the
+// proxy's domain, and to clear the proxy domain's storage entirely.
+const originSecurityContextHeaders = [
+  'set-cookie',
+  'strict-transport-security',
+  'content-security-policy',
+  'content-security-policy-report-only',
+  'access-control-allow-origin',
+  'access-control-allow-credentials',
+  'access-control-allow-methods',
+  'access-control-allow-headers',
+  'access-control-expose-headers',
+  'access-control-max-age',
+  'clear-site-data',
+]
+
 type Headers = {
   [key: string]: string
 }
@@ -56,14 +74,33 @@ export function excludeContentDependentHeaders(headers: Headers): Headers {
 }
 
 /**
- * Exclude unused headers from the response headers. (Hop-by-hop headers and content-dependent headers)
+ * Exclude origin-bound security context headers from the response headers.
+ * These headers encode security policies for the origin's domain (cookies,
+ * HSTS, CSP, CORS, Clear-Site-Data) and must not be forwarded to the proxy
+ * client, where they would apply to the proxy's domain instead.
+ * @param headers {Headers}
+ * @returns headers {Headers}
+ */
+export function excludeOriginSecurityContextHeaders(headers: Headers): Headers {
+  const result: Headers = {}
+  for (const key in headers) {
+    if (originSecurityContextHeaders.includes(key)) {
+      continue
+    }
+    result[key] = headers[key]
+  }
+  return result
+}
+
+/**
+ * Exclude unused headers from the response headers.
+ * Removes hop-by-hop headers, content-dependent headers, and
+ * origin-bound security context headers that must not cross the trust boundary.
  * @param headers {Headers}
  * @returns headers {Headers}
  */
 export function excludeUnusedHeaders(headers: Headers): Headers {
-  return {
-    ...excludeContentDependentHeaders({
-      ...excludeHopByHopHeaders(headers),
-    }),
-  }
+  return excludeOriginSecurityContextHeaders(
+    excludeContentDependentHeaders(excludeHopByHopHeaders(headers)),
+  )
 }


### PR DESCRIPTION
## Summary

- `excludeUnusedHeaders` only dropped hop-by-hop and content-dependent headers. All remaining origin response headers — including `Set-Cookie`, `Strict-Transport-Security`, `Content-Security-Policy`, CORS headers, and `Clear-Site-Data` — were forwarded to the proxy client unchanged.
- A malicious origin could exploit this trust boundary gap: `Set-Cookie` could set or overwrite cookies on the proxy's domain; `Clear-Site-Data` could wipe the proxy's storage; HSTS/CSP/CORS directives would apply to the proxy's domain rather than the origin's.
- Added `excludeOriginSecurityContextHeaders()`, which removes headers whose semantics are bound to the origin's domain context, and wired it into `excludeUnusedHeaders()`.

## Changed files

- `src/lib/headers.ts` — `originSecurityContextHeaders` list + `excludeOriginSecurityContextHeaders()` function + updated `excludeUnusedHeaders()` to call it
- `src/lib/headers.spec.ts` — tests for `excludeOriginSecurityContextHeaders` (all-headers stripped, pass-through for unrelated headers); updated `excludeUnusedHeaders` test to include `set-cookie`

## Stripped headers

| Header | Risk if forwarded |
|--------|------------------|
| `set-cookie` | Origin sets/overwrites cookies on the proxy domain (session fixation, auth disruption) |
| `strict-transport-security` | Origin's HSTS policy applies to the proxy domain |
| `content-security-policy` | Origin's CSP restricts or widens the proxy domain's content policy |
| `content-security-policy-report-only` | Same as CSP (report-only mode) |
| `access-control-allow-origin` | Origin's CORS policy applies to the proxy domain |
| `access-control-allow-credentials` | Widens credential sharing on the proxy domain |
| `access-control-allow-methods` | Widens allowed methods on the proxy domain |
| `access-control-allow-headers` | Widens allowed request headers on the proxy domain |
| `access-control-expose-headers` | Widens exposed response headers on the proxy domain |
| `access-control-max-age` | Preflight cache duration applied to the proxy domain |
| `clear-site-data` | Origin can wipe the proxy domain's caches, cookies, and storage |

## Test plan

- [ ] `npx tsc --noEmit` — type-checks pass
- [ ] `npx biome check .` — no lint errors
- [ ] `npx vitest run src/lib/headers.spec.ts src/index.spec.ts` — 6 tests pass

## Trade-offs

- **Blocklist approach**: this PR uses a blocklist (explicit headers to remove) rather than an allowlist (only headers explicitly approved for forwarding). A blocklist may miss future headers that carry domain-bound semantics. The allowlist approach was considered as a design option but is out of scope for this change due to its larger impact on response compatibility.