### PR TITLE
fix: fail CI when test matrix jobs fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
       HOME: /root
       RUNNING_IN_DOCKER: "1"
 
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/src/ci_workflows.spec.ts
+++ b/src/ci_workflows.spec.ts
@@ -1,0 +1,14 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('test workflow failure handling', () => {
+  const testWorkflowPath = '.github/workflows/test.yml'
+  const testWorkflowIt = existsSync(testWorkflowPath) ? it : it.skip
+
+  testWorkflowIt('runs all matrix entries without masking failures', () => {
+    const workflow = readFileSync(testWorkflowPath, 'utf8')
+
+    expect(workflow).toContain('fail-fast: false')
+    expect(workflow).not.toMatch(/^\s*continue-on-error:\s*true\s*$/m)
+  })
+})


### PR DESCRIPTION
Summary:
- Remove `continue-on-error` from the test matrix job so lint, typecheck, test, and build failures fail the PR check.
- Keep `fail-fast: false` so all Node matrix entries still run.
- Add a regression test for the workflow failure-handling settings.

Tests:
- `bun run format`
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bunx vitest run src/ci_workflows.spec.ts`
- `bun run test`
- `bun run build`
- `bun pm pack`
- `bunx madge --circular --extensions ts src`
- `git diff --check`
- `docker compose -f docker/docker-compose.yml build`
- `docker compose -f docker/docker-compose.yml up -d`
- `docker compose -f docker/docker-compose.yml exec rendering-proxy-chromium bun run test`
- `docker compose -f docker/docker-compose.yml exec rendering-proxy-firefox bun run test`
- `docker compose -f docker/docker-compose.yml down`

Note: This PR is based on #1608 so the Docker check runs against the fixed Playwright runtime image. Local Docker runs passed with the existing httpbin platform warning on this arm64 host.
