### PR TITLE
fix: add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to enable weekly Dependabot update PRs for npm packages, Docker images, and GitHub Actions pins.

This repository depends on Playwright (which bundles Chromium/Firefox/WebKit binaries) and several other packages. Without automated dependency tracking, CVEs registered in the npm advisory database would not surface until manually noticed.

## Changes

- **`.github/dependabot.yml`** (new): schedules weekly update PRs for `npm`, `docker` (under `/docker`), and `github-actions`.

## Note on CI-level vulnerability scanning

A companion change to add `bun audit` to the test workflow (`.github/workflows/test.yml`) was prepared but requires a token with the `workflow` scope to push. The workflow change would add a dedicated `audit` job:

```yaml
  audit:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
        with:
          bun-version: 1.3.11
      - name: Install dependencies
        run: bun install --frozen-lockfile
      - name: Audit dependencies
        run: bun audit
```

This can be appended to `test.yml` by a maintainer who has a token with the `workflow` scope.

## Validation

- `bun run lint` — pass (biome, no issues)
- `bunx madge --circular --extensions ts src/` — no circular dependencies
- `dependabot.yml` schema is valid per [Dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

## Trade-offs

- Dependabot update PRs add review load. The weekly cadence keeps batches small.
- Dependabot version updates are distinct from security alerts; alerts are enabled separately in repository settings (Security → Dependabot alerts).