### PR TITLE
fix: support tag-driven release publishing

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    tags:
+      - 'v*.*.*'
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
@@ -17,7 +20,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Validate stable release tag
+        if: github.event_name == 'push'
+        run: |
+          set -eu
+          if ! printf '%s' "$GITHUB_REF_NAME" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "tag pushes only publish stable vMAJOR.MINOR.PATCH tags" >&2
+            exit 1
+          fi
+
       - name: Log in to Docker Hub
+        if: github.event_name == 'push' || (github.event_name == 'release' && !github.event.release.prerelease)
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -31,10 +44,9 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        if: github.event_name == 'release' && !github.event.release.prerelease
         with:
           context: .
           file: docker/Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' || (github.event_name == 'release' && !github.event.release.prerelease) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    tags:
+      - 'v*.*.*'
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
@@ -11,7 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  verify:
+    name: Verify package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -30,8 +34,64 @@ jobs:
           bun install --frozen-lockfile
           bun run build
 
+      - run: npm pack
+
+      - name: Test installation
+        run: |
+          set -eu
+          built_dir=$(pwd)
+          tarball=$(find "$built_dir" -maxdepth 1 -name '*.tgz' -print -quit)
+          if [ -z "$tarball" ]; then
+            echo "expected packed tarball was not found" >&2
+            exit 1
+          fi
+          tempdir=$(mktemp -d)
+          trap 'rm -rf "$tempdir"' EXIT
+          cd "$tempdir"
+          printf '{"name":"tmp","private":true}\n' > package.json
+          bun add "file:$tarball"
+          bunx --bun rendering-proxy --help
+          cd "$built_dir"
+          rm -rf "$tempdir"
+          trap - EXIT
+
+  publish:
+    name: Publish package
+    needs: verify
+    if: github.event_name == 'push' || (github.event_name == 'release' && !github.event.release.prerelease)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.11
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: install and build
+        run: |
+          bun install --frozen-lockfile
+          bun run build
+
+      - name: Validate stable release tag
+        if: github.event_name == 'push'
+        run: |
+          set -eu
+          if ! printf '%s' "$GITHUB_REF_NAME" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "tag pushes only publish stable vMAJOR.MINOR.PATCH tags" >&2
+            exit 1
+          fi
+
       - name: update version
-        if: github.event_name == 'release'
         run: |
           git config user.email "dummy@dummy"
           git config user.name "dummy"
@@ -51,14 +111,43 @@ jobs:
             exit 1
           fi
           tempdir=$(mktemp -d)
+          trap 'rm -rf "$tempdir"' EXIT
           cd "$tempdir"
           printf '{"name":"tmp","private":true}\n' > package.json
           bun add "file:$tarball"
           bunx --bun rendering-proxy --help
           cd "$built_dir"
           rm -rf "$tempdir"
+          trap - EXIT
 
-      - run: npm publish
-        if: github.event_name == 'release' && !github.event.release.prerelease
+      - name: Check published package version
+        id: npm_version
+        run: |
+          set -eu
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if npm view "rendering-proxy@$version" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - run: npm publish --provenance
+        if: steps.npm_version.outputs.published == 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release for tag pushes
+        if: github.event_name == 'push'
+        run: |
+          set -eu
+          tag="${GITHUB_REF_NAME}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "GitHub Release $tag already exists"
+          else
+            gh release create "$tag" --verify-tag --generate-notes
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Summary:
- add stable `vMAJOR.MINOR.PATCH` tag push triggers for npm and Docker release workflows
- split npm package verification from publishing, with publish limited to stable tag pushes or non-prerelease release events
- add npm provenance, duplicate-version guard, GitHub Release creation for tag pushes, and PR-safe Docker login/push guards

Validation:
- `actionlint .github/workflows/release.yml .github/workflows/docker-release.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/release.yml .github/workflows/docker-release.yml`
- `bun install --frozen-lockfile`
- `git ls-files -z | xargs -0 bunx biome check --write --files-ignore-unknown=true`
- `bun run typecheck`
- `bun run build`
- `bun pm pack`
- `bunx madge --circular --extensions ts src`
- `bunx vitest run --coverage --hookTimeout 30000 --testTimeout 30000 --exclude '.tmp/**' $(git ls-files '*spec.ts')`

Notes:
- This PR is stacked on #1608 so Docker CI uses the already-validated Playwright image alignment.
