### PR TITLE
fix: add 30s timeout to browser connection polling loop

### DIFF
--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -36,6 +36,9 @@ const firefoxOptions = ['-wait-for-browser']
 
 const webkitOptions: string[] = []
 
+const BROWSER_CONNECT_TIMEOUT_MS = 30_000
+const BROWSER_CONNECT_POLL_INTERVAL_MS = 100
+
 export function getBrowserTypeByName(name: SelectableBrowsers): BrowserType {
   switch (name) {
     case 'chromium':
@@ -74,9 +77,15 @@ export async function getBrowser({
     headless,
     args: getBrowserOptionsByName(name),
   })
-  // Wait for the browser to be ready.
+  const deadline = Date.now() + BROWSER_CONNECT_TIMEOUT_MS
   while (!browser.isConnected()) {
-    await sleep(100)
+    if (Date.now() >= deadline) {
+      await browser.close().catch(() => {})
+      throw new Error(
+        `Browser did not connect within ${BROWSER_CONNECT_TIMEOUT_MS}ms`,
+      )
+    }
+    await sleep(BROWSER_CONNECT_POLL_INTERVAL_MS)
   }
   return browser
 }


### PR DESCRIPTION
## Summary

`getBrowser()` in `src/browser/index.ts` polled `browser.isConnected()` in a `while` loop with no upper bound. If the browser process launched but never became connected (OS resource exhaustion, Playwright race condition), the loop would spin indefinitely at 100 ms intervals, hanging the server.

This PR:
- Adds a 30-second deadline before entering the loop
- Throws a descriptive error and closes the browser if the deadline is reached
- Names the previously magic-number constants (`BROWSER_CONNECT_TIMEOUT_MS`, `BROWSER_CONNECT_POLL_INTERVAL_MS`)

## Test plan

- [ ] All existing tests pass (`bun run test` — 35/35)
- [ ] `bun run lint` passes (biome check)
- [ ] `bun run typecheck` passes (tsc --noEmit)
- [ ] The timeout path (lines 82–88) is not covered by the existing test suite — it requires mocking the browser connection state, which is outside this PR's scope

## Trade-offs

The 30-second value is a conservative default that covers slow CI environments. If Playwright's `launch()` itself applies its own timeout (currently ~30 s), this deadline acts as a redundant safety net for the post-launch connection check.