### PR TITLE
Handle CLI entrypoint errors

### DIFF
--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  CliUsageError,
+  formatCliError,
+  getCliExitCode,
+  main,
+  validateURLArgument,
+} from './main'
+
+function packageVersion(): string {
+  const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as {
+    version: string
+  }
+  return pkg.version
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('main entrypoint', () => {
+  it('prints package version', async () => {
+    const outputs: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((message?: unknown) => {
+      outputs.push(String(message))
+    })
+
+    await main(['--version'])
+
+    expect(outputs.join('')).toContain(packageVersion())
+  })
+
+  it('rejects missing commands as usage errors', async () => {
+    await expect(main([])).rejects.toMatchObject({
+      exitCode: 2,
+      message: 'You need at least one command before moving on',
+      name: 'CliUsageError',
+    })
+  })
+
+  it('rejects invalid URLs before starting browser work', async () => {
+    expect(() => validateURLArgument('bad host')).toThrow(CliUsageError)
+    await expect(main(['cli', '--url', 'bad host'])).rejects.toMatchObject({
+      exitCode: 2,
+      message: 'Invalid URL: bad host',
+      name: 'CliUsageError',
+    })
+  })
+
+  it('formats usage and runtime errors with distinct exit codes', () => {
+    const usageError = new CliUsageError('bad input')
+    const runtimeError = new Error('browser failed')
+
+    expect(getCliExitCode(usageError)).toBe(2)
+    expect(formatCliError(usageError)).toBe(
+      'rendering-proxy: Usage error: bad input',
+    )
+    expect(getCliExitCode(runtimeError)).toBe(1)
+    expect(formatCliError(runtimeError)).toBe(
+      'rendering-proxy: Error: browser failed',
+    )
+  })
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,78 @@
 import yargs from 'yargs'
 import { cli, server } from './'
 import { type SelectableBrowsers, selectableBrowsers } from './browser'
+import { ensureURLStartsWithProtocolScheme } from './lib/url'
 import { type LifecycleEvent, lifeCycleEvents } from './render'
 
-export async function main(): Promise<void> {
-  yargs(process.argv.slice(2))
+const usageErrorExitCode = 2
+const runtimeErrorExitCode = 1
+
+export class CliUsageError extends Error {
+  readonly exitCode = usageErrorExitCode
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'CliUsageError'
+  }
+}
+
+export function validateURLArgument(url: string): string {
+  const normalizedURL = ensureURLStartsWithProtocolScheme(url)
+  try {
+    new URL(normalizedURL)
+  } catch {
+    throw new CliUsageError(`Invalid URL: ${url}`)
+  }
+  return url
+}
+
+function handleYargsFailure(
+  message: string | null,
+  error: Error | null,
+): never {
+  throw yargsFailureError(message, error)
+}
+
+function yargsFailureError(message: string | null, error: Error | null): Error {
+  if (error instanceof CliUsageError) {
+    return error
+  }
+  if (!message) {
+    return error ?? new CliUsageError('Invalid CLI arguments')
+  }
+  return new CliUsageError(message)
+}
+
+export function getCliExitCode(error: unknown): number {
+  if (error instanceof CliUsageError) {
+    return error.exitCode
+  }
+  return runtimeErrorExitCode
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}
+
+export function formatCliError(error: unknown): string {
+  const label = error instanceof CliUsageError ? 'Usage error' : 'Error'
+  return `rendering-proxy: ${label}: ${errorMessage(error)}`
+}
+
+export function handleMainError(error: unknown): never {
+  console.error(formatCliError(error))
+  process.exit(getCliExitCode(error))
+}
+
+export async function main(args = process.argv.slice(2)): Promise<void> {
+  await yargs(args)
+    .scriptName('rendering-proxy')
+    .version()
+    .exitProcess(false)
+    .fail(handleYargsFailure)
     .command(
       'cli',
       'Render a page from the command line',
@@ -16,6 +84,7 @@ export async function main(): Promise<void> {
             type: 'string',
             description: 'URL to render',
             demandOption: true,
+            coerce: validateURLArgument,
           })
           .option('waitUntil', {
             alias: 'w',
@@ -74,9 +143,11 @@ export async function main(): Promise<void> {
       },
     )
     .demandCommand(1, 'You need at least one command before moving on')
-    .help().argv
+    .strictCommands()
+    .help()
+    .parseAsync()
 }
 
 if (require.main === module) {
-  main()
+  main().catch(handleMainError)
 }


### PR DESCRIPTION
## Summary
- await yargs parsing so async command handler failures propagate through the CLI entrypoint
- add explicit top-level error handling with distinct usage and runtime exit codes
- enable package version output and validate CLI URL input before browser work starts

## Validation
- `bun install --frozen-lockfile`
- `bunx biome check --files-ignore-unknown=true src/main.ts src/main.spec.ts`
- `git ls-files -z | xargs -0 bunx biome check --files-ignore-unknown=true`
- `bun run typecheck`
- `bunx vitest run src/main.spec.ts --hookTimeout 30000 --testTimeout 30000`
- `bunx vitest run --coverage --hookTimeout 30000 --testTimeout 30000 --exclude '.tmp/**' $(git ls-files '*spec.ts')`
- `bun run build`
- `bun pm pack`
- `bunx madge --circular --extensions ts src`
- `git diff --check`

## Notes
- This PR is stacked on #1608 so the Docker-based checks use the Playwright runtime image update.
- Local `bun run lint` is blocked by ignored local `.tmp/worktrees` checkouts that contain nested Biome root configs; the tracked-file Biome checks above cover the repository files in this branch.
