### PR TITLE
chore: remove unused .prettierrc.json

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,0 @@
-{
-  "trailingComma": "es5",
-  "tabWidth": 2,
-  "semi": true,
-  "singleQuote": true
-}


### PR DESCRIPTION
## Summary

Remove `.prettierrc.json` which was never used by CI.

Biome is the sole formatter and linter (`npm run lint` / `npm run format` both use `biome check`). The Prettier config file was dead weight that caused IDE confusion: editors with the Prettier extension would apply Prettier formatting instead of Biome's, producing diffs that `biome check` would reject.

## Changes

- Delete `.prettierrc.json`

## Verification

- `bun run lint` (Biome): 29 files checked, no issues
- `bun run test`: 9 test files, 35 tests — all passed
- `tsc --noEmit`: 0 type errors
