### PR TITLE
fix: reject non-http/https URL schemes in ensureURLStartsWithProtocolScheme

### DIFF
--- a/src/lib/url.spec.ts
+++ b/src/lib/url.spec.ts
@@ -30,4 +30,16 @@ describe('ensureURLStartsWithProtocolScheme', () => {
       'https://example.com',
     )
   })
+
+  it('throws when given URL with non-http/https scheme', () => {
+    expect(() =>
+      ensureURLStartsWithProtocolScheme('file:///etc/passwd'),
+    ).toThrow('Unsupported URL scheme: file:')
+    expect(() =>
+      ensureURLStartsWithProtocolScheme('data:text/html,hello'),
+    ).toThrow('Unsupported URL scheme: data:')
+    expect(() =>
+      ensureURLStartsWithProtocolScheme('ftp://example.com'),
+    ).toThrow('Unsupported URL scheme: ftp:')
+  })
 })

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -11,7 +11,11 @@ export function ensureURLStartsWithProtocolScheme(
   url: string,
   scheme = 'https://',
 ): string {
-  if (urlParse(url).protocol) {
+  const protocol = urlParse(url).protocol
+  if (protocol) {
+    if (!isAbsoluteURL(url)) {
+      throw new Error(`Unsupported URL scheme: ${protocol}`)
+    }
     return url
   }
   return scheme + url


### PR DESCRIPTION
## Summary

The CLI and server modes had asymmetric URL scheme validation. The server
rejects non-`http://`/`https://` URLs via `isAbsoluteURL`, but the CLI
passed them through `ensureURLStartsWithProtocolScheme` to Playwright
unchanged. This allowed `file://`, `data:`, `ftp://`, and other schemes
to reach `page.goto()` without any validation.

## Changes

**`src/lib/url.ts`**: `ensureURLStartsWithProtocolScheme` now throws
`Error('Unsupported URL scheme: <scheme>')` when the input URL already has
a non-`http`/`https` protocol. URLs with no scheme still default to `https://`
as before.

**`src/lib/url.spec.ts`**: Added test cases for `file://`, `data:`, and
`ftp://` inputs that verify the new error is thrown.

## Rationale

- The server's `resolveOriginUrl` already calls `isAbsoluteURL` and returns
  `null` for non-http/https URLs, producing a 204 response.
- Aligning the CLI to reject the same inputs removes the behavioral
  asymmetry and prevents unexpected Playwright interactions with local
  files or data URIs.
- The fix is in the shared utility so any future caller gets the
  validation automatically.

## Verification

`bun run test src/lib/url.spec.ts` — 5 tests pass including the 3 new
cases. Broader suite (`src/lib/`, `src/server/`, `src/index.spec.ts`) —
17 tests pass.
