### PR TITLE
fix: await server close and drain idle connections on shutdown

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -130,6 +130,13 @@ export function terminateRequestWithEmpty(
   res.end()
 }
 
+function closeServerGracefully(server: http.Server): Promise<void> {
+  server.closeIdleConnections()
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()))
+  })
+}
+
 /**
  * Start rendering proxy server.
  * @param port {number} port number
@@ -147,7 +154,7 @@ export async function main({
     defer(() => browser.close())
 
     const server = await createServer({ browser, port })
-    defer(() => server.close())
+    defer(() => closeServerGracefully(server))
 
     await waitForProcessExit()
   })


### PR DESCRIPTION
## Summary

The `server.close()` call registered via `defer` was not returning a
Promise, so `runWithDefer` would `await` a non-Promise value and resolve
immediately — without waiting for active connections to drain.  As a
result, `browser.close()` could be called while requests were still
in-flight, causing Playwright to throw "Browser has been closed" errors
and leaving clients waiting for a response that would never arrive.

## Changes

- Extract `closeServerGracefully(server)` helper that:
  1. Calls `server.closeIdleConnections()` to immediately release
     keep-alive connections that have no active request.
  2. Wraps `server.close(callback)` in a `Promise<void>` so
     `runWithDefer` properly awaits full drain before proceeding.
- Replace `defer(() => server.close())` in `main()` with
  `defer(() => closeServerGracefully(server))`.

## Verification

- `bun run format` — no issues
- `bun run lint` — no issues
- `bun run typecheck` — no issues
- `bun run test` — 36/36 tests pass
- `madge --circular --extensions ts,tsx src/` — no circular dependencies
