### PR TITLE
chore: track package version in source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,16 @@ jobs:
           bun install --frozen-lockfile
           bun run build
 
-      - name: update version
+      - name: Validate release version
         if: github.event_name == 'release'
         run: |
-          git config user.email "dummy@dummy"
-          git config user.name "dummy"
-          npm version from-git --allow-same-version
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          set -eu
+          package_version=$(node -p "require('./package.json').version")
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$package_version" != "$tag_version" ]; then
+            echo "release tag v${tag_version} does not match package.json version ${package_version}" >&2
+            exit 1
+          fi
 
       - run: npm pack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,13 @@ Build the package when changing package metadata, exports, or runtime entrypoint
 bun run build
 ```
 
+## Releases
+
+The npm package version is tracked in `package.json`. Before creating a release
+tag, bump `package.json` in a pull request and tag the merged commit as
+`vX.Y.Z`. The release workflow checks that the tag and package version match
+before publishing.
+
 ## Pull requests
 
 Before opening a pull request, please make sure that:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "name": "rendering-proxy",
   "description": "Proxy to get the DOM rendered in a headless browser",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary
- `package.json` now tracks `0.1.3` as the source of truth for the published package version.
- The release workflow now validates that the release tag matches `package.json` instead of mutating the version with `npm version from-git`.
- `CONTRIBUTING.md` now documents the release flow: bump the package version first, then create the release tag after the merged commit.

## Changed files
- `.github/workflows/release.yml`
- `CONTRIBUTING.md`
- `package.json`

## Verification
- `bun install --frozen-lockfile`
- `actionlint`
- `git diff --check`
- `bun run lint`
- `bun run typecheck`
- `typos`
- `node -e "const v=require('./package.json').version; if (v !== '0.1.3') process.exit(1)"`
- `bun run test`
- `bun run build`
- `npm pack` + temporary `bun add` + `bunx --bun rendering-proxy --help`
- `bun pm pack`
- `docker compose -f docker/docker-compose.yml build rendering-proxy-chromium rendering-proxy-firefox`
- `docker compose -f docker/docker-compose.yml up -d rendering-proxy-chromium rendering-proxy-firefox httpbin`
- `curl -fsS http://127.0.0.1:8080/health/`
- `curl -fsS http://127.0.0.1:8081/health/`
- `docker compose -f docker/docker-compose.yml down`
- implement-validator: overall pass
