### PR TITLE
docs: add CHANGELOG and programmatic API usage to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0]
+
+This is the first version tracked in this changelog.
+For prior history, see the [git log](https://github.com/kitsuyui/rendering-proxy/commits/main).

--- a/README.md
+++ b/README.md
@@ -139,6 +139,87 @@ This sets up two hooks that mirror what CI runs:
 
 CI still runs the full suite on every pull request and push to main — the hooks bring that feedback earlier, to your local machine.
 
+## Programmatic API
+
+`rendering-proxy` exports two namespaces for programmatic use:
+
+```ts
+import { server, cli } from 'rendering-proxy'
+```
+
+### `server.main(options?)`
+
+Starts the rendering proxy HTTP server. Exits when the process receives `SIGTERM` or `SIGINT`.
+
+```ts
+import { server } from 'rendering-proxy'
+
+await server.main({ port: 8080, name: 'chromium', headless: true })
+```
+
+Options:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `port` | `number` | `8080` | Port to listen on |
+| `name` | `'chromium' \| 'firefox' \| 'webkit'` | `'chromium'` | Browser engine |
+| `headless` | `boolean` | `true` | Run browser in headless mode |
+
+### `server.createServer({ browser, port })`
+
+Creates an `http.Server` backed by a pre-launched Playwright `Browser` instance.
+
+```ts
+import { chromium } from 'playwright'
+import { server } from 'rendering-proxy'
+
+const browser = await chromium.launch()
+const httpServer = await server.createServer({ browser, port: 8080 })
+// Use httpServer.close() to stop
+```
+
+### `server.createHandler(browser)`
+
+Returns a `(req, res) => void` handler suitable for use with an existing `http.Server`.
+
+```ts
+import http from 'node:http'
+import { chromium } from 'playwright'
+import { server } from 'rendering-proxy'
+
+const browser = await chromium.launch()
+const httpServer = http.createServer(server.createHandler(browser))
+httpServer.listen(8080)
+```
+
+### `cli.renderToStream(request, writable)`
+
+Renders a URL and writes the resulting HTML to any `Writable` stream.
+
+```ts
+import { cli } from 'rendering-proxy'
+
+await cli.renderToStream(
+  {
+    url: 'https://example.com',
+    name: 'chromium',
+    waitUntil: 'networkidle',
+    evaluates: ['document.title = "patched"'],
+  },
+  process.stdout,
+)
+```
+
+### `cli.main(request)`
+
+Renders a URL and writes to `process.stdout`. Equivalent to the CLI command.
+
+```ts
+import { cli } from 'rendering-proxy'
+
+await cli.main({ url: 'https://example.com', name: 'chromium' })
+```
+
 ## LICENSE
 
 The 3-Clause BSD License. See also LICENSE file.


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format
- Adds a **Programmatic API** section to `README.md` documenting the `server` and `cli` namespaces exported from `src/index.ts`

## Motivation

`rendering-proxy` is published as an npm package (`version: 0.1.0`) with `dist/index.d.ts` type definitions. The `src/index.ts` re-exports both `server` and `cli` namespaces, so consumers can import the library programmatically — but until now there was no example or reference for how to do so. Similarly, a package without a CHANGELOG makes it difficult for consumers to evaluate the impact of version updates.

## Changes

- `CHANGELOG.md`: initial file anchored to `0.1.0`; points to git log for full prior history
- `README.md`: new `## Programmatic API` section documenting `server.main`, `server.createServer`, `server.createHandler`, `cli.renderToStream`, and `cli.main` with TypeScript examples

## Verification

- `biome check .` passes (30 files, no issues)
- No TypeScript source files changed

## Trade-offs

The CHANGELOG starts from `0.1.0` with a pointer to git log rather than back-filling every historical release; back-filling would be error-prone and the git log already captures that history accurately.
