### PR TITLE
ci(octocov): add 80% coverage threshold to prevent regression

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,6 +2,7 @@
 coverage:
   paths:
     - coverage/clover.xml
+  acceptable: 80%
 codeToTestRatio:
   code:
     - "src/**/*.ts"


### PR DESCRIPTION
## Summary

Add `coverage.acceptable: 80%` to `.octocov.yml` so that a coverage drop
below 80% will fail the octocov CI job rather than silently pass.

**Why this matters:** Without a threshold, coverage metrics are recorded in
the dashboard but never block a PR. This means coverage could regress over
time with no automated signal.

## Change

```diff
 coverage:
   paths:
     - coverage/clover.xml
+  acceptable: 80%
```

## Verification

Current coverage (from `bun run test` with `@vitest/coverage-v8`):
- Statements: 86.49% — above threshold
- Branches: 80.00% — at threshold  
- Functions: 83.13% — above threshold
- Lines: 87.33% — above threshold

All metrics satisfy the new threshold. `bun run lint` and `bun run format`
also pass with no findings. No circular dependencies detected (`madge --circular`).

## Trade-offs

- `src/main.ts` currently has 0% coverage (CLI entry point). This threshold
  does not address that gap directly; a separate effort to add integration
  tests for the CLI entry point would be needed to cover those paths.
- 80% is intentionally below current coverage to avoid failing on the first
  PR after this lands while leaving the threshold meaningful.