### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ x-rendering-proxy: [{"success":true,"result":2,"script":"1 + 1"}]
     <title>Example Domain</title>
 ```
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and register the Git hooks:
+
+```sh
+lefthook install
+```
+
+This sets up two hooks that mirror what CI runs:
+
+- **pre-commit**: runs `bun run lint` and `bun run typecheck` on every commit.
+- **pre-push**: runs `bun run lint`, `bun run typecheck`, and `bun run test` before each push.
+
+CI still runs the full suite on every pull request and push to main — the hooks bring that feedback earlier, to your local machine.
+
 ## LICENSE
 
 The 3-Clause BSD License. See also LICENSE file.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: lint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run lint
+    - name: typecheck
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run typecheck
+
+pre-push:
+  jobs:
+    - name: lint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run lint
+    - name: typecheck
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run typecheck
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` that mirrors the same checks CI runs (lint, typecheck, test) as local Git hooks
- Adds a `## Development` section to `README.md` explaining how to install and what each hook runs
- CI workflows are untouched

## What the hooks do

- **pre-commit**: `bun run lint` + `bun run typecheck` — fast static checks on every commit
- **pre-push**: `bun run lint` + `bun run typecheck` + `bun run test` — full suite before each push

Each job clears `GIT_*` environment variables so nested/sibling repositories are not affected.

## Verification

All mirrored checks were verified to pass on the current `main` before creating this PR:
- `bun run lint` — passed
- `bun run typecheck` — passed
- `bun run test` — 51/51 tests passed

CI still runs the full suite on every pull request and push to main.
