### PR TITLE
Parallelize independent workflow checks

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -47,17 +47,18 @@ jobs:
         run: |
           bun install --frozen-lockfile
 
-      - name: Lint
-        run: bun run lint
+      - parallel:
+          - name: Lint
+            run: bun run lint
 
-      - name: typecheck
-        run: bun run typecheck
+          - name: typecheck
+            run: bun run typecheck
 
-      - name: Test
-        run: bun run test
+          - name: Test
+            run: bun run test
 
-      - name: Build
-        run: bun run build
+          - name: Build
+            run: bun run build
 
       - name: Test packaging
         run: bun pm pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,17 +52,18 @@ jobs:
         run: |
           bun install --frozen-lockfile
 
-      - name: Lint
-        run: bun run lint
+      - parallel:
+          - name: Lint
+            run: bun run lint
 
-      - name: typecheck
-        run: bun run typecheck
+          - name: typecheck
+            run: bun run typecheck
 
-      - name: Test
-        run: bun run test
+          - name: Test
+            run: bun run test
 
-      - name: Build
-        run: bun run build
+          - name: Build
+            run: bun run build
 
       - name: Mark workspace as a safe Git directory
         if: matrix.node-version == '24.x'


### PR DESCRIPTION
## Summary
- Run independent lint, type-check, test, and build steps through GitHub Actions `parallel` groups.
- Keep packaging, safe-directory setup, build-size measurement, and coverage reporting after the parallel group.

## Verification
- Parsed the updated workflows as YAML.
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun pm pack`
- `bun run test` requires Docker locally; CI provides a container and httpbin service for this job.
