### PR TITLE
fix: reject repeated x-rendering-proxy headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ x-rendering-proxy-version: 1
 
 #### Protocol schema (v1)
 
-**Request header** `X-Rendering-Proxy` — JSON object:
+**Request header** `X-Rendering-Proxy` — a single JSON object header value:
 
 | field | type | default | description |
 | --- | --- | --- | --- |
@@ -113,7 +113,7 @@ x-rendering-proxy-version: 1
 | `evaluates` | `string[]` | `[]` | JavaScript snippets to evaluate before capturing the DOM. |
 | `timeout` | `number` (ms) | none | Navigation timeout in milliseconds. |
 
-Requests with a non-object `X-Rendering-Proxy` JSON payload or with fields of the wrong type are rejected with `400 Bad Request`.
+Requests with a repeated `X-Rendering-Proxy` header, a non-object JSON payload, or fields of the wrong type are rejected with `400 Bad Request`.
 
 **Response header** `X-Rendering-Proxy` — JSON array of `EvaluateResult`:
 

--- a/src/server/request_options.spec.ts
+++ b/src/server/request_options.spec.ts
@@ -21,7 +21,16 @@ describe('parseRenderingProxyHeader', () => {
     })
   })
 
-  it('throws for syntactically invalid JSON in a non-empty header', async () => {
+  it('rejects repeated x-rendering-proxy header values', async () => {
+    expect(() =>
+      parseRenderingProxyHeader([
+        '{"evaluates":["1 + 1"]}',
+        '{"waitUntil":"load"}',
+      ]),
+    ).toThrow(TypeError)
+  })
+
+  it('throws SyntaxError for syntactically invalid JSON in a non-empty header', async () => {
     // Callers (e.g. the HTTP server) must catch and return 400 Bad Request
     expect(() => parseRenderingProxyHeader('{')).toThrow(SyntaxError)
     expect(() => parseRenderingProxyHeader('[unclosed')).toThrow(SyntaxError)

--- a/src/server/request_options.ts
+++ b/src/server/request_options.ts
@@ -15,6 +15,18 @@ type RequestOptionInput = {
   timeout?: unknown
 }
 
+function normalizeHeaderArray(headerValue: string[]): string {
+  if (headerValue.length === 0) {
+    return ''
+  }
+  if (headerValue.length === 1) {
+    return headerValue[0] ?? ''
+  }
+  throw new TypeError(
+    'X-Rendering-Proxy must be provided as a single header value',
+  )
+}
+
 export function parseRenderingProxyHeader(
   headerValue: undefined | string | string[],
 ): RequestOption {
@@ -22,7 +34,7 @@ export function parseRenderingProxyHeader(
     return parseOptions(headerValue)
   }
   if (Array.isArray(headerValue)) {
-    return parseOptions(headerValue.join(''))
+    return parseOptions(normalizeHeaderArray(headerValue))
   }
   return parseOptions('')
 }


### PR DESCRIPTION
## Summary
- reject repeated `X-Rendering-Proxy` request header values instead of concatenating them implicitly
- document that the server accepts a single JSON object header value for `X-Rendering-Proxy`
- cover the repeated-header case with a parser test

## Why
The protocol documentation already describes `X-Rendering-Proxy` as a single JSON object. Rejecting repeated header values makes the server behavior deterministic and avoids relying on implicit string concatenation for duplicate headers.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test`
