### PR TITLE
fix: preserve all rendering proxy evaluate scripts

### DIFF
--- a/src/server/request_options.spec.ts
+++ b/src/server/request_options.spec.ts
@@ -116,12 +116,12 @@ describe('parseRenderingProxyHeader', () => {
     })
   })
 
-  it('truncates evaluates to at most 10 entries', async () => {
+  it('keeps all evaluate entries without truncation', async () => {
     const scripts = Array.from({ length: 20 }, (_, i) => `script${i}`)
     const result = parseRenderingProxyHeader(
       JSON.stringify({ evaluates: scripts }),
     )
-    expect(result.evaluates).toHaveLength(10)
-    expect(result.evaluates).toStrictEqual(scripts.slice(0, 10))
+    expect(result.evaluates).toHaveLength(20)
+    expect(result.evaluates).toStrictEqual(scripts)
   })
 })

--- a/src/server/request_options.ts
+++ b/src/server/request_options.ts
@@ -36,8 +36,6 @@ function normalizeWaitUntil(value: unknown): LifecycleEvent {
   return 'load'
 }
 
-const MAX_EVALUATES = 10
-
 function normalizeEvaluates(value: unknown): string[] {
   if (
     !Array.isArray(value) ||
@@ -45,7 +43,7 @@ function normalizeEvaluates(value: unknown): string[] {
   ) {
     return []
   }
-  return value.slice(0, MAX_EVALUATES)
+  return value
 }
 
 function normalizeTimeout(value: unknown): number | undefined {


### PR DESCRIPTION
## Summary
- preserve all `evaluates` entries from the `X-Rendering-Proxy` request header
- remove the server-only silent truncation that dropped scripts after the first 10 entries
- update the header parsing regression test to cover unbounded passthrough

## Why
Server mode exposed `evaluates` as a plain `string[]`, but the request parser silently discarded entries after the first 10. That made later scripts disappear without an error even though the programmatic API and README describe the field as a normal string array.

## Testing
- bun run lint
- bun run typecheck
- bun run test
